### PR TITLE
Update trading fees on build

### DIFF
--- a/contracts/OverlayV1Market.sol
+++ b/contracts/OverlayV1Market.sol
@@ -108,22 +108,19 @@ contract OverlayV1Market {
     ) external returns (uint256 positionId_) {
         require(leverage >= ONE, "OVLV1:lev<min");
         require(leverage <= capLeverage, "OVLV1:lev>max");
+        require(collateral >= minCollateral, "OVLV1:collateral<min");
 
         Oracle.Data memory data = update();
 
-        // amount of collateral to transfer in to back the position
-        uint256 collateralIn = collateral;
-
-        // calculate oi adjusted for fees. fees are taken from collateral
+        // calculate oi and fees. fees are added to collateral needed to
+        // transfer in to back a position
         // TODO: change minOi to minSlippage since impact now on price
         uint256 oi = collateral.mulUp(leverage);
         uint256 capOiAdjusted = capOiWithAdjustments(data);
         uint256 tradingFee = oi.mulUp(tradingFeeRate);
-        collateral -= tradingFee;
-        oi = collateral.mulUp(leverage);
 
-        require(collateral >= minCollateral, "OVLV1:collateral<min");
-        require(oi >= minOi, "OVLV1:oi<min");
+        // amount of collateral to transfer in + fees
+        uint256 collateralIn = collateral + tradingFee;
 
         // add new position's open interest to the side's aggregate oi value
         // and increase number of oi shares issued

--- a/contracts/OverlayV1Market.sol
+++ b/contracts/OverlayV1Market.sol
@@ -103,8 +103,7 @@ contract OverlayV1Market {
     function build(
         uint256 collateral,
         uint256 leverage,
-        bool isLong,
-        uint256 minOi
+        bool isLong
     ) external returns (uint256 positionId_) {
         require(leverage >= ONE, "OVLV1:lev<min");
         require(leverage <= capLeverage, "OVLV1:lev>max");
@@ -114,7 +113,6 @@ contract OverlayV1Market {
 
         // calculate oi and fees. fees are added to collateral needed to
         // transfer in to back a position
-        // TODO: change minOi to minSlippage since impact now on price
         uint256 oi = collateral.mulUp(leverage);
         uint256 capOiAdjusted = capOiWithAdjustments(data);
         uint256 tradingFee = oi.mulUp(tradingFeeRate);
@@ -137,6 +135,7 @@ contract OverlayV1Market {
         // longs get the ask and shorts get the bid on build
         // register the additional volume taking either the ask or bid
         // TODO: pack snapshotVolumes to get gas close to 200k
+        // TODO: add maxSlippage input param to bid(), ask()
         uint256 volume = isLong
             ? _registerVolumeAsk(data, oi, capOiAdjusted)
             : _registerVolumeBid(data, oi, capOiAdjusted);

--- a/tests/markets/test_build.py
+++ b/tests/markets/test_build.py
@@ -14,17 +14,15 @@ def isolation(fn_isolation):
 
 def calculate_position_info(oi: Decimal,
                             leverage: Decimal,
-                            trading_fee_rate: Decimal,
-                            cap_oi: Decimal) -> (Decimal, Decimal, Decimal,
-                                                 Decimal, Decimal):
+                            trading_fee_rate: Decimal) -> (Decimal, Decimal,
+                                                           Decimal, Decimal):
+    """
+    Returns position attributes in decimal format (int / 1e18)
+    """
     collateral = oi / leverage
     trade_fee = oi * trading_fee_rate
-
-    collateral_adjusted = collateral - trade_fee
-    oi_adjusted = collateral_adjusted * leverage
-    debt = oi_adjusted - collateral_adjusted
-
-    return collateral_adjusted, oi_adjusted, debt, trade_fee
+    debt = oi - collateral
+    return collateral, oi, debt, trade_fee
 
 
 @given(
@@ -35,13 +33,22 @@ def test_build_creates_position(market, feed, ovl, alice, oi, leverage,
                                 is_long):
     expect_pos_id = market.nextPositionId()
 
-    input_collateral = int(oi / leverage * Decimal(1e18))
+    # calculate expected pos info data
+    trading_fee_rate = Decimal(market.tradingFeeRate() / 1e18)
+    collateral, oi, debt, trade_fee \
+        = calculate_position_info(oi, leverage, trading_fee_rate)
+
+    # input values for tx
+    input_collateral = int((collateral) * Decimal(1e18))
     input_leverage = int(leverage * Decimal(1e18))
     input_is_long = is_long
     input_min_oi = 0  # NOTE: testing for min_oi below
 
+    # approve collateral amount: collateral + trade fee
+    approve_collateral = int((collateral + trade_fee) * Decimal(1e18))
+
     # approve market for spending then build
-    ovl.approve(market, input_collateral, {"from": alice})
+    ovl.approve(market, approve_collateral, {"from": alice})
     tx = market.build(input_collateral, input_leverage, input_is_long,
                       input_min_oi, {"from": alice})
 
@@ -49,16 +56,11 @@ def test_build_creates_position(market, feed, ovl, alice, oi, leverage,
     actual_pos_id = tx.return_value
     assert actual_pos_id == expect_pos_id
 
-    # calculate expected pos info data
-    trading_fee_rate = Decimal(market.tradingFeeRate() / 1e18)
-    cap_oi = Decimal(market.capOi() / 1e18)
-    collateral_adjusted, oi_adjusted, debt, _ \
-        = calculate_position_info(oi, leverage, trading_fee_rate, cap_oi)
-
     # calculate expected entry price
     # NOTE: ask(), bid() tested in test_price.py
     data = feed.latest()
-    volume = int((oi_adjusted / cap_oi) * Decimal(1e18))
+    cap_oi = Decimal(market.capOi() / 1e18)
+    volume = int((oi / cap_oi) * Decimal(1e18))
     price = market.ask(data, volume) if is_long \
         else market.bid(data, volume)
 
@@ -66,9 +68,9 @@ def test_build_creates_position(market, feed, ovl, alice, oi, leverage,
     expect_leverage = int(leverage * Decimal(1e18))
     expect_is_long = is_long
     expect_entry_price = price
-    expect_oi_shares = int(oi_adjusted * Decimal(1e18))
+    expect_oi_shares = int(oi * Decimal(1e18))
     expect_debt = int(debt * Decimal(1e18))
-    expect_cost = int(collateral_adjusted * Decimal(1e18))
+    expect_cost = int(collateral * Decimal(1e18))
 
     # check position info
     actual_pos = market.positions(actual_pos_id)
@@ -78,9 +80,9 @@ def test_build_creates_position(market, feed, ovl, alice, oi, leverage,
     assert actual_leverage == expect_leverage
     assert actual_is_long == expect_is_long
     assert int(actual_entry_price) == approx(expect_entry_price)
-    assert int(actual_oi_shares) == approx(expect_oi_shares, rel=1e-4)
-    assert int(actual_debt) == approx(expect_debt, rel=1e-4)
-    assert int(actual_cost) == approx(expect_cost, rel=1e-4)
+    assert int(actual_oi_shares) == approx(expect_oi_shares)
+    assert int(actual_debt) == approx(expect_debt)
+    assert int(actual_cost) == approx(expect_cost)
 
 
 @given(
@@ -88,10 +90,19 @@ def test_build_creates_position(market, feed, ovl, alice, oi, leverage,
     leverage=strategy('decimal', min_value='1.0', max_value='5.0', places=3),
     is_long=strategy('bool'))
 def test_build_adds_oi(market, ovl, alice, oi, leverage, is_long):
-    input_collateral = int(oi / leverage * Decimal(1e18))
+    # calculate expected pos info data
+    trading_fee_rate = Decimal(market.tradingFeeRate() / 1e18)
+    collateral, oi, debt, trade_fee \
+        = calculate_position_info(oi, leverage, trading_fee_rate)
+
+    # input values for tx
+    input_collateral = int(collateral * Decimal(1e18))
     input_leverage = int(leverage * Decimal(1e18))
     input_is_long = is_long
     input_min_oi = 0  # NOTE: testing for min_oi below
+
+    # approve collateral amount: collateral + trade fee
+    approve_collateral = int((collateral + trade_fee) * Decimal(1e18))
 
     # priors actual values
     _ = market.update({"from": alice})  # update funding prior
@@ -100,25 +111,20 @@ def test_build_adds_oi(market, ovl, alice, oi, leverage, is_long):
         if is_long else market.oiShortShares()
 
     # approve market for spending then build
-    ovl.approve(market, input_collateral, {"from": alice})
+    ovl.approve(market, approve_collateral, {"from": alice})
     _ = market.build(input_collateral, input_leverage, input_is_long,
                      input_min_oi, {"from": alice})
 
     # calculate expected oi info data
-    trading_fee_rate = Decimal(market.tradingFeeRate() / 1e18)
-    cap_oi = Decimal(market.capOi() / 1e18)
-    _, oi_adjusted, _, _ = calculate_position_info(oi, leverage,
-                                                   trading_fee_rate,
-                                                   cap_oi)
-    expect_oi += int(oi_adjusted * Decimal(1e18))
-    expect_oi_shares += int(oi_adjusted * Decimal(1e18))
+    expect_oi += int(oi * Decimal(1e18))
+    expect_oi_shares += int(oi * Decimal(1e18))
 
     # compare with actual aggregate oi values
     actual_oi = market.oiLong() if is_long else market.oiShort()
     actual_oi_shares = market.oiLongShares() if is_long else market.oiShort()
 
-    assert int(actual_oi) == approx(expect_oi, rel=1e-4)
-    assert int(actual_oi_shares) == approx(expect_oi_shares, rel=1e-4)
+    assert int(actual_oi) == approx(expect_oi)
+    assert int(actual_oi_shares) == approx(expect_oi_shares)
 
 
 @given(
@@ -127,10 +133,19 @@ def test_build_adds_oi(market, ovl, alice, oi, leverage, is_long):
     is_long=strategy('bool'))
 def test_build_registers_volume(market, feed, ovl, alice, oi, leverage,
                                 is_long):
-    input_collateral = int(oi / leverage * Decimal(1e18))
+    # calculate expected pos info data
+    trading_fee_rate = Decimal(market.tradingFeeRate() / 1e18)
+    collateral, oi, debt, trade_fee \
+        = calculate_position_info(oi, leverage, trading_fee_rate)
+
+    # input values for the tx
+    input_collateral = int(collateral * Decimal(1e18))
     input_leverage = int(leverage * Decimal(1e18))
     input_is_long = is_long
     input_min_oi = 0  # NOTE: testing for min_oi below
+
+    # approve collateral amount: collateral + trade fee
+    approve_collateral = int((collateral + trade_fee) * Decimal(1e18))
 
     # priors actual values
     _ = market.update({"from": alice})  # update funding prior
@@ -139,22 +154,16 @@ def test_build_registers_volume(market, feed, ovl, alice, oi, leverage,
     last_timestamp, last_window, last_volume = snapshot_volume
 
     # approve market for spending then build
-    ovl.approve(market, input_collateral, {"from": alice})
+    ovl.approve(market, approve_collateral, {"from": alice})
     tx = market.build(input_collateral, input_leverage, input_is_long,
                       input_min_oi, {"from": alice})
-
-    # calculate expected oi info data
-    trading_fee_rate = Decimal(market.tradingFeeRate() / 1e18)
-    cap_oi = Decimal(market.capOi() / 1e18)
-    _, oi_adjusted, _, _ = calculate_position_info(oi, leverage,
-                                                   trading_fee_rate,
-                                                   cap_oi)
 
     # calculate expected rolling volume and window numbers when
     # adjusted for decay
     # NOTE: decayOverWindow() tested in test_rollers.py
     _, micro_window, _, _, _, _, _, _ = feed.latest()
-    input_volume = int((oi_adjusted / cap_oi) * Decimal(1e18))
+    cap_oi = Decimal(market.capOi() / 1e18)
+    input_volume = int((oi / cap_oi) * Decimal(1e18))
     input_window = micro_window
     input_timestamp = chain[tx.block_number]['timestamp']
 
@@ -190,22 +199,28 @@ def test_build_registers_volume(market, feed, ovl, alice, oi, leverage,
     is_long=strategy('bool'))
 def test_build_executes_transfers(market, ovl, alice, oi, leverage,
                                   is_long):
-    input_collateral = int(oi / leverage * Decimal(1e18))
+    # calculate expected pos info data
+    trading_fee_rate = Decimal(market.tradingFeeRate() / 1e18)
+    collateral, oi, debt, trade_fee \
+        = calculate_position_info(oi, leverage, trading_fee_rate)
+
+    # input values for the tx
+    input_collateral = int(collateral * Decimal(1e18))
     input_leverage = int(leverage * Decimal(1e18))
     input_is_long = is_long
     input_min_oi = 0  # NOTE: testing for min_oi below
 
+    # approve collateral amount: collateral + trade fee
+    # amount of collateral that will be transferred in
+    approve_collateral = int((collateral + trade_fee) * Decimal(1e18))
+
     # approve market for spending then build
-    ovl.approve(market, input_collateral, {"from": alice})
+    ovl.approve(market, approve_collateral, {"from": alice})
     tx = market.build(input_collateral, input_leverage, input_is_long,
                       input_min_oi, {"from": alice})
 
-    # calculate expected info data
-    trading_fee_rate = Decimal(market.tradingFeeRate() / 1e18)
-    cap_oi = Decimal(market.capOi() / 1e18)
-    _, _, _, trade_fee = calculate_position_info(oi, leverage,
-                                                 trading_fee_rate, cap_oi)
-
+    # expected values
+    expect_collateral_in = approve_collateral
     expect_trade_fee = int(trade_fee * Decimal(1e18))
 
     # check Transfer events for:
@@ -216,13 +231,13 @@ def test_build_executes_transfers(market, ovl, alice, oi, leverage,
     # check collateral in event (1)
     assert tx.events['Transfer'][0]['from'] == alice.address
     assert tx.events['Transfer'][0]['to'] == market.address
-    assert int(tx.events['Transfer'][0]['value']) == input_collateral
+    assert int(tx.events['Transfer'][0]['value']) == \
+        approx(expect_collateral_in)
 
     # check trade fee out event (2)
     assert tx.events['Transfer'][1]['from'] == market.address
     assert tx.events['Transfer'][1]['to'] == market.tradingFeeRecipient()
-    assert int(tx.events['Transfer'][1]['value']) == approx(expect_trade_fee,
-                                                            rel=1e-4)
+    assert int(tx.events['Transfer'][1]['value']) == approx(expect_trade_fee)
 
 
 @given(
@@ -231,35 +246,40 @@ def test_build_executes_transfers(market, ovl, alice, oi, leverage,
     is_long=strategy('bool'))
 def test_build_transfers_collateral_to_market(market, ovl, alice, oi,
                                               leverage, is_long):
-    input_collateral = int(oi / leverage * Decimal(1e18))
+    # calculate expected pos info data
+    trading_fee_rate = Decimal(market.tradingFeeRate() / 1e18)
+    collateral, oi, debt, trade_fee \
+        = calculate_position_info(oi, leverage, trading_fee_rate)
+
+    # input values for the tx
+    input_collateral = int(collateral * Decimal(1e18))
     input_leverage = int(leverage * Decimal(1e18))
     input_is_long = is_long
     input_min_oi = 0  # NOTE: testing for min_oi below
+
+    # approve collateral amount: collateral + trade fee
+    # amount of collateral that will be transferred in
+    approve_collateral = int((collateral + trade_fee) * Decimal(1e18))
 
     # priors actual values
     expect_balance_alice = ovl.balanceOf(alice)
     expect_balance_market = ovl.balanceOf(market)
 
     # approve market for spending then build
-    ovl.approve(market, input_collateral, {"from": alice})
+    ovl.approve(market, approve_collateral, {"from": alice})
     _ = market.build(input_collateral, input_leverage, input_is_long,
                      input_min_oi, {"from": alice})
 
     # calculate expected collateral info data
-    trading_fee_rate = Decimal(market.tradingFeeRate() / 1e18)
-    cap_oi = Decimal(market.capOi() / 1e18)
-    collateral_adjusted, _, _, _ = calculate_position_info(oi, leverage,
-                                                           trading_fee_rate,
-                                                           cap_oi)
-    expect_balance_alice -= input_collateral
-    expect_balance_market += int(collateral_adjusted * Decimal(1e18))
+    expect_collateral_in = int((collateral + trade_fee) * Decimal(1e18))
+    expect_balance_alice -= expect_collateral_in
+    expect_balance_market += int(collateral * Decimal(1e18))
 
     actual_balance_alice = ovl.balanceOf(alice)
     actual_balance_market = ovl.balanceOf(market)
 
-    assert int(actual_balance_alice) == approx(expect_balance_alice, rel=1e-4)
-    assert int(actual_balance_market) == approx(expect_balance_market,
-                                                rel=1e-4)
+    assert int(actual_balance_alice) == approx(expect_balance_alice)
+    assert int(actual_balance_market) == approx(expect_balance_market)
 
 
 @given(
@@ -268,26 +288,29 @@ def test_build_transfers_collateral_to_market(market, ovl, alice, oi,
     is_long=strategy('bool'))
 def test_build_transfers_trading_fees(market, ovl, alice, oi,
                                       leverage, is_long):
-    input_collateral = int(oi / leverage * Decimal(1e18))
+    # calculate expected pos info data
+    trading_fee_rate = Decimal(market.tradingFeeRate() / 1e18)
+    collateral, oi, debt, trade_fee \
+        = calculate_position_info(oi, leverage, trading_fee_rate)
+
+    # input values for the tx
+    input_collateral = int(collateral * Decimal(1e18))
     input_leverage = int(leverage * Decimal(1e18))
     input_is_long = is_long
     input_min_oi = 0  # NOTE: testing for min_oi below
+
+    # approve collateral amount: collateral + trade fee
+    # amount of collateral that will be transferred in
+    approve_collateral = int((collateral + trade_fee) * Decimal(1e18))
 
     # priors actual values
     recipient = market.tradingFeeRecipient()
     expect = ovl.balanceOf(recipient)
 
     # approve market for spending then build
-    ovl.approve(market, input_collateral, {"from": alice})
+    ovl.approve(market, approve_collateral, {"from": alice})
     _ = market.build(input_collateral, input_leverage, input_is_long,
                      input_min_oi, {"from": alice})
-
-    # calculate expected collateral info data
-    trading_fee_rate = Decimal(market.tradingFeeRate() / 1e18)
-    cap_oi = Decimal(market.capOi() / 1e18)
-    _, _, _, trade_fee = calculate_position_info(oi, leverage,
-                                                 trading_fee_rate,
-                                                 cap_oi)
 
     expect += int(trade_fee * Decimal(1e18))
     actual = ovl.balanceOf(recipient)
@@ -303,7 +326,7 @@ def test_build_reverts_when_leverage_less_than_one(market, ovl, alice):
     input_min_oi = 0
 
     # approve market for spending before build
-    ovl.approve(market, input_collateral, {"from": alice})
+    ovl.approve(market, 2**256-1, {"from": alice})
 
     # check build reverts when input leverage is less than one (ONE = 1e18)
     input_leverage = int(Decimal(1e18) - 1)
@@ -330,8 +353,8 @@ def test_build_reverts_when_leverage_greater_than_cap(market, ovl, alice):
     input_is_long = True
     input_min_oi = 0
 
-    # approve market for spending before build
-    ovl.approve(market, input_collateral, {"from": alice})
+    # approve market for spending before build. Use the max just for here
+    ovl.approve(market, 2**256 - 1, {"from": alice})
 
     # check build reverts when input leverage is less than one (ONE = 1e18)
     input_leverage = market.capLeverage() + 1
@@ -351,45 +374,7 @@ def test_build_reverts_when_leverage_greater_than_cap(market, ovl, alice):
     assert actual_leverage == expect_leverage
 
 
-@given(
-    oi=strategy('decimal', min_value='0.001', max_value='800000', places=3),
-    leverage=strategy('decimal', min_value='1.0', max_value='5.0', places=3),
-    is_long=strategy('bool'))
-def test_build_reverts_when_oi_less_than_min(market, ovl, alice, oi, leverage,
-                                             is_long):
-    expect_pos_id = market.nextPositionId()
-
-    input_collateral = int(oi / leverage * Decimal(1e18))
-    input_leverage = int(leverage * Decimal(1e18))
-    input_is_long = is_long
-
-    # approve market for spending before build
-    ovl.approve(market, input_collateral, {"from": alice})
-
-    # calculate expected oi info data before build to use for min oi value
-    trading_fee_rate = Decimal(market.tradingFeeRate() / 1e18)
-    cap_oi = Decimal(market.capOi() / 1e18)
-    _, oi_adjusted, _, _ = calculate_position_info(oi, leverage,
-                                                   trading_fee_rate,
-                                                   cap_oi)
-
-    tol = 1e-4  # tolerance put at +/- 1bps
-    input_min_oi = int(oi_adjusted * Decimal(1+tol) * Decimal(1e18))
-
-    # check build reverts for min_oi > oi_adjusted (w tolerance)
-    with reverts("OVLV1:oi<min"):
-        _ = market.build(input_collateral, input_leverage, input_is_long,
-                         input_min_oi, {"from": alice})
-
-    # check build succeeds for min_oi < oi_adjusted (w tolerance)
-    input_min_oi = int(oi_adjusted * Decimal(1-tol) * Decimal(1e18))
-
-    _ = market.build(input_collateral, input_leverage, input_is_long,
-                     input_min_oi, {"from": alice})
-
-    expect_pos_id += 1
-    actual_pos_id = market.nextPositionId()
-    assert expect_pos_id == actual_pos_id
+# TODO: def test_build_reverts_when_slippage_greater_than_max:
 
 
 @given(
@@ -402,27 +387,18 @@ def test_build_reverts_when_collateral_less_than_min(market, ovl, alice,
     input_leverage = int(leverage * Decimal(1e18))
     input_is_long = is_long
     input_min_oi = 0
+    input_collateral = market.minCollateral() - 1
 
-    tol = 1e-4  # tolerance put at +/- 1bps
-    min_collateral = market.minCollateral()
-    trading_fee_rate = Decimal(market.tradingFeeRate() / 1e18)
+    # approve market for spending then build. use max
+    ovl.approve(market, 2**256 - 1, {"from": alice})
 
-    # check build reverts for min_collateral > collateral (w tolerance)
-    input_min_collateral = Decimal(min_collateral) / \
-        Decimal(1 - leverage * trading_fee_rate)
-    input_collateral = int(input_min_collateral * Decimal(1-tol))
-
-    # approve market for spending then build
-    ovl.approve(market, int(input_min_collateral * Decimal(1+tol)),
-                {"from": alice})
-
-    # check build reverts for min_collat > collat_adjusted (w tolerance)
+    # check build reverts for min_collat > collat
     with reverts("OVLV1:collateral<min"):
         _ = market.build(input_collateral, input_leverage, input_is_long,
                          input_min_oi, {"from": alice})
 
-    # check build succeeds for min_collat < collat_adjusted (w tolerance)
-    input_collateral = int(input_min_collateral * Decimal(1+tol))
+    # check build succeeds for min_collat <= collat
+    input_collateral = market.minCollateral()
     _ = market.build(input_collateral, input_leverage, input_is_long,
                      input_min_oi, {"from": alice})
 
@@ -441,41 +417,32 @@ def test_build_reverts_when_oi_greater_than_cap(market, ovl, alice, is_long):
     input_is_long = is_long
     input_min_oi = 0
 
-    # decimals for leverage and trading fee rate for input collateral calc
-    tol = 1e-4  # tolerance put at +/- 1bps
-    trading_fee_rate = Decimal(market.tradingFeeRate() / 1e18)
-    leverage = Decimal(input_leverage) / Decimal(1e18)
-
-    # approve market for spending before build
-    input_collateral = Decimal(market.capOi() * (1+tol)) / \
-        Decimal(1 - leverage * trading_fee_rate)
-    ovl.approve(market, input_collateral, {"from": alice})
+    # approve market for spending before build. use max
+    ovl.approve(market, 2**256 - 1, {"from": alice})
 
     # check build reverts when oi is greater than static cap
+    input_collateral = market.capOi() + 1
     with reverts("OVLV1:oi>cap"):
         _ = market.build(input_collateral, input_leverage, input_is_long,
                          input_min_oi, {"from": alice})
 
     # check build succeeds when oi is equal to cap
-    input_collateral = Decimal(market.capOi() * (1-tol)) / \
-        Decimal(1 - leverage * trading_fee_rate)
+    input_collateral = market.capOi()
     _ = market.build(input_collateral, input_leverage, input_is_long,
                      input_min_oi, {"from": alice})
 
     # calculate expected pos info data
-    input_oi = int(Decimal(input_collateral * leverage) / Decimal(1e18))
-    cap_oi = Decimal(market.capOi() / 1e18)
-    collateral_adjusted, oi_adjusted, debt, _ \
-        = calculate_position_info(input_oi, leverage, trading_fee_rate,
-                                  cap_oi)
+    leverage = 1
+    oi = int(Decimal(input_collateral * leverage) / Decimal(1e18))
+    collateral = int(Decimal(input_collateral) / Decimal(1e18))
 
     # expect values
-    expect_oi_shares = int(oi_adjusted * Decimal(1e18))
-    expect_cost = int(collateral_adjusted * Decimal(1e18))
+    expect_oi_shares = int(oi * Decimal(1e18))
+    expect_cost = int(collateral * Decimal(1e18))
 
     # check position info
     actual_pos = market.positions(expect_pos_id)
     (_, _, _, actual_oi_shares, _, actual_cost) = actual_pos
 
-    assert int(actual_oi_shares) == approx(expect_oi_shares, rel=1e-4)
-    assert int(actual_cost) == approx(expect_cost, rel=1e-4)
+    assert int(actual_oi_shares) == approx(expect_oi_shares)
+    assert int(actual_cost) == approx(expect_cost)

--- a/tests/markets/test_build.py
+++ b/tests/markets/test_build.py
@@ -42,7 +42,6 @@ def test_build_creates_position(market, feed, ovl, alice, oi, leverage,
     input_collateral = int((collateral) * Decimal(1e18))
     input_leverage = int(leverage * Decimal(1e18))
     input_is_long = is_long
-    input_min_oi = 0  # NOTE: testing for min_oi below
 
     # approve collateral amount: collateral + trade fee
     approve_collateral = int((collateral + trade_fee) * Decimal(1e18))
@@ -50,7 +49,7 @@ def test_build_creates_position(market, feed, ovl, alice, oi, leverage,
     # approve market for spending then build
     ovl.approve(market, approve_collateral, {"from": alice})
     tx = market.build(input_collateral, input_leverage, input_is_long,
-                      input_min_oi, {"from": alice})
+                      {"from": alice})
 
     # check position id
     actual_pos_id = tx.return_value
@@ -99,7 +98,6 @@ def test_build_adds_oi(market, ovl, alice, oi, leverage, is_long):
     input_collateral = int(collateral * Decimal(1e18))
     input_leverage = int(leverage * Decimal(1e18))
     input_is_long = is_long
-    input_min_oi = 0  # NOTE: testing for min_oi below
 
     # approve collateral amount: collateral + trade fee
     approve_collateral = int((collateral + trade_fee) * Decimal(1e18))
@@ -113,7 +111,7 @@ def test_build_adds_oi(market, ovl, alice, oi, leverage, is_long):
     # approve market for spending then build
     ovl.approve(market, approve_collateral, {"from": alice})
     _ = market.build(input_collateral, input_leverage, input_is_long,
-                     input_min_oi, {"from": alice})
+                     {"from": alice})
 
     # calculate expected oi info data
     expect_oi += int(oi * Decimal(1e18))
@@ -142,7 +140,6 @@ def test_build_registers_volume(market, feed, ovl, alice, oi, leverage,
     input_collateral = int(collateral * Decimal(1e18))
     input_leverage = int(leverage * Decimal(1e18))
     input_is_long = is_long
-    input_min_oi = 0  # NOTE: testing for min_oi below
 
     # approve collateral amount: collateral + trade fee
     approve_collateral = int((collateral + trade_fee) * Decimal(1e18))
@@ -156,7 +153,7 @@ def test_build_registers_volume(market, feed, ovl, alice, oi, leverage,
     # approve market for spending then build
     ovl.approve(market, approve_collateral, {"from": alice})
     tx = market.build(input_collateral, input_leverage, input_is_long,
-                      input_min_oi, {"from": alice})
+                      {"from": alice})
 
     # calculate expected rolling volume and window numbers when
     # adjusted for decay
@@ -208,7 +205,6 @@ def test_build_executes_transfers(market, ovl, alice, oi, leverage,
     input_collateral = int(collateral * Decimal(1e18))
     input_leverage = int(leverage * Decimal(1e18))
     input_is_long = is_long
-    input_min_oi = 0  # NOTE: testing for min_oi below
 
     # approve collateral amount: collateral + trade fee
     # amount of collateral that will be transferred in
@@ -217,7 +213,7 @@ def test_build_executes_transfers(market, ovl, alice, oi, leverage,
     # approve market for spending then build
     ovl.approve(market, approve_collateral, {"from": alice})
     tx = market.build(input_collateral, input_leverage, input_is_long,
-                      input_min_oi, {"from": alice})
+                      {"from": alice})
 
     # expected values
     expect_collateral_in = approve_collateral
@@ -255,7 +251,6 @@ def test_build_transfers_collateral_to_market(market, ovl, alice, oi,
     input_collateral = int(collateral * Decimal(1e18))
     input_leverage = int(leverage * Decimal(1e18))
     input_is_long = is_long
-    input_min_oi = 0  # NOTE: testing for min_oi below
 
     # approve collateral amount: collateral + trade fee
     # amount of collateral that will be transferred in
@@ -268,7 +263,7 @@ def test_build_transfers_collateral_to_market(market, ovl, alice, oi,
     # approve market for spending then build
     ovl.approve(market, approve_collateral, {"from": alice})
     _ = market.build(input_collateral, input_leverage, input_is_long,
-                     input_min_oi, {"from": alice})
+                     {"from": alice})
 
     # calculate expected collateral info data
     expect_collateral_in = int((collateral + trade_fee) * Decimal(1e18))
@@ -297,7 +292,6 @@ def test_build_transfers_trading_fees(market, ovl, alice, oi,
     input_collateral = int(collateral * Decimal(1e18))
     input_leverage = int(leverage * Decimal(1e18))
     input_is_long = is_long
-    input_min_oi = 0  # NOTE: testing for min_oi below
 
     # approve collateral amount: collateral + trade fee
     # amount of collateral that will be transferred in
@@ -310,7 +304,7 @@ def test_build_transfers_trading_fees(market, ovl, alice, oi,
     # approve market for spending then build
     ovl.approve(market, approve_collateral, {"from": alice})
     _ = market.build(input_collateral, input_leverage, input_is_long,
-                     input_min_oi, {"from": alice})
+                     {"from": alice})
 
     expect += int(trade_fee * Decimal(1e18))
     actual = ovl.balanceOf(recipient)
@@ -323,7 +317,6 @@ def test_build_reverts_when_leverage_less_than_one(market, ovl, alice):
 
     input_collateral = int(100 * Decimal(1e18))
     input_is_long = True
-    input_min_oi = 0
 
     # approve market for spending before build
     ovl.approve(market, 2**256-1, {"from": alice})
@@ -332,12 +325,12 @@ def test_build_reverts_when_leverage_less_than_one(market, ovl, alice):
     input_leverage = int(Decimal(1e18) - 1)
     with reverts("OVLV1:lev<min"):
         _ = market.build(input_collateral, input_leverage, input_is_long,
-                         input_min_oi, {"from": alice})
+                         {"from": alice})
 
     # check build succeeds when input leverage is equal to one
     input_leverage = int(Decimal(1e18))
     _ = market.build(input_collateral, input_leverage, input_is_long,
-                     input_min_oi, {"from": alice})
+                     {"from": alice})
 
     # check position info
     expect_leverage = input_leverage
@@ -351,7 +344,6 @@ def test_build_reverts_when_leverage_greater_than_cap(market, ovl, alice):
 
     input_collateral = int(100 * Decimal(1e18))
     input_is_long = True
-    input_min_oi = 0
 
     # approve market for spending before build. Use the max just for here
     ovl.approve(market, 2**256 - 1, {"from": alice})
@@ -360,12 +352,12 @@ def test_build_reverts_when_leverage_greater_than_cap(market, ovl, alice):
     input_leverage = market.capLeverage() + 1
     with reverts("OVLV1:lev>max"):
         _ = market.build(input_collateral, input_leverage, input_is_long,
-                         input_min_oi, {"from": alice})
+                         {"from": alice})
 
     # check build succeeds when input leverage is equal to cap
     input_leverage = market.capLeverage()
     _ = market.build(input_collateral, input_leverage, input_is_long,
-                     input_min_oi, {"from": alice})
+                     {"from": alice})
 
     # check position info
     expect_leverage = input_leverage
@@ -386,7 +378,6 @@ def test_build_reverts_when_collateral_less_than_min(market, ovl, alice,
 
     input_leverage = int(leverage * Decimal(1e18))
     input_is_long = is_long
-    input_min_oi = 0
     input_collateral = market.minCollateral() - 1
 
     # approve market for spending then build. use max
@@ -395,12 +386,12 @@ def test_build_reverts_when_collateral_less_than_min(market, ovl, alice,
     # check build reverts for min_collat > collat
     with reverts("OVLV1:collateral<min"):
         _ = market.build(input_collateral, input_leverage, input_is_long,
-                         input_min_oi, {"from": alice})
+                         {"from": alice})
 
     # check build succeeds for min_collat <= collat
     input_collateral = market.minCollateral()
     _ = market.build(input_collateral, input_leverage, input_is_long,
-                     input_min_oi, {"from": alice})
+                     {"from": alice})
 
     expect_pos_id += 1
     actual_pos_id = market.nextPositionId()
@@ -415,7 +406,6 @@ def test_build_reverts_when_oi_greater_than_cap(market, ovl, alice, is_long):
 
     input_leverage = int(1e18)
     input_is_long = is_long
-    input_min_oi = 0
 
     # approve market for spending before build. use max
     ovl.approve(market, 2**256 - 1, {"from": alice})
@@ -424,12 +414,12 @@ def test_build_reverts_when_oi_greater_than_cap(market, ovl, alice, is_long):
     input_collateral = market.capOi() + 1
     with reverts("OVLV1:oi>cap"):
         _ = market.build(input_collateral, input_leverage, input_is_long,
-                         input_min_oi, {"from": alice})
+                         {"from": alice})
 
     # check build succeeds when oi is equal to cap
     input_collateral = market.capOi()
     _ = market.build(input_collateral, input_leverage, input_is_long,
-                     input_min_oi, {"from": alice})
+                     {"from": alice})
 
     # calculate expected pos info data
     leverage = 1


### PR DESCRIPTION
Alters the way markets take trading fees by increasing amount of OVL transferred in to the contract. `collateral` input specified in `build()` changes to resulting collateral backing the position.

Such that

`collateralIn = collateral + tradeFees`

where `tradeFees = collateral * leverage * tradingFeeRate`