### PR TITLE
Refactor positions as a mapping

### DIFF
--- a/contracts/OverlayV1Market.sol
+++ b/contracts/OverlayV1Market.sol
@@ -146,14 +146,18 @@ contract OverlayV1Market {
         // store the position info data
         // TODO: pack position.info to get gas close to 200k
         positionId_ = _totalPositions;
-        positions.set(msg.sender, positionId_, Position.Info({
-            leverage: leverage,
-            isLong: isLong,
-            entryPrice: price,
-            oiShares: oi,
-            debt: oi - collateral,
-            cost: collateral
-        }));
+        positions.set(
+            msg.sender,
+            positionId_,
+            Position.Info({
+                leverage: leverage,
+                isLong: isLong,
+                entryPrice: price,
+                oiShares: oi,
+                debt: oi - collateral,
+                cost: collateral
+            })
+        );
         _totalPositions++;
 
         // transfer in the OVL collateral needed to back the position

--- a/contracts/libraries/Position.sol
+++ b/contracts/libraries/Position.sol
@@ -21,7 +21,7 @@ library Position {
                         POSITIONS MAPPING FUNCTIONS
     //////////////////////////////////////////////////////////////*/
 
-    // TODO: test ...
+    /// @notice Retrieves a position from positions mapping
     function get(
         mapping(bytes32 => Info) storage self,
         address owner,
@@ -30,7 +30,7 @@ library Position {
         position_ = self[keccak256(abi.encodePacked(owner, id))];
     }
 
-    // TODO: test ...
+    /// @notice Stores a position in positions mapping
     function set(
         mapping(bytes32 => Info) storage self,
         address owner,

--- a/contracts/libraries/Position.sol
+++ b/contracts/libraries/Position.sol
@@ -17,6 +17,33 @@ library Position {
         uint256 cost; // amount of collateral initially locked
     }
 
+    /*///////////////////////////////////////////////////////////////
+                        POSITIONS MAPPING FUNCTIONS
+    //////////////////////////////////////////////////////////////*/
+
+    // TODO: test ...
+    function get(
+        mapping(bytes32 => Info) storage self,
+        address owner,
+        uint256 id
+    ) internal view returns (Info storage position_) {
+        position_ = self[keccak256(abi.encodePacked(owner, id))];
+    }
+
+    // TODO: test ...
+    function set(
+        mapping(bytes32 => Info) storage self,
+        address owner,
+        uint256 id,
+        Info memory position
+    ) internal {
+        self[keccak256(abi.encodePacked(owner, id))] = position;
+    }
+
+    /*///////////////////////////////////////////////////////////////
+                            POSITION FUNCTIONS
+    //////////////////////////////////////////////////////////////*/
+
     function initialOi(Info memory self) internal view returns (uint256) {
         return _initialOi(self);
     }

--- a/contracts/mocks/PositionMock.sol
+++ b/contracts/mocks/PositionMock.sol
@@ -4,7 +4,23 @@ pragma solidity 0.8.10;
 import "../libraries/Position.sol";
 
 contract PositionMock {
+    using Position for mapping(bytes32 => Position.Info);
     using Position for Position.Info;
+
+    mapping(bytes32 => Position.Info) public positions;
+
+    function get(address owner, uint256 id) external view returns (Position.Info memory) {
+        Position.Info memory position = positions.get(owner, id);
+        return position;
+    }
+
+    function set(
+        address owner,
+        uint256 id,
+        Position.Info memory pos
+    ) external {
+        positions.set(owner, id, pos);
+    }
 
     function initialOi(Position.Info memory pos) external view returns (uint256) {
         return pos.initialOi();

--- a/tests/libraries/position/test_positions.py
+++ b/tests/libraries/position/test_positions.py
@@ -1,0 +1,54 @@
+from brownie import web3
+from hexbytes import HexBytes
+
+
+def get_position_key(owner: str, id: int) -> HexBytes:
+    """
+    Returns the position key to retrieve an individual position
+    from positions mapping
+    """
+    return web3.solidityKeccak(['address', 'uint256'], [owner, id])
+
+
+def test_positions_setter(position, alice):
+    owner = alice
+    id = 0
+
+    leverage = 5000000000000000000  # 5x
+    is_long = True
+    entry_price = 100000000000000000000  # 100
+    oi = 10000000000000000000  # 10
+    debt = 8000000000000000000  # 8
+    cost = 2000000000000000000  # 2
+
+    pos = (leverage, is_long, entry_price, oi, debt, cost)
+    position.set(owner, id, pos)
+
+    # pos key
+    pos_key = get_position_key(alice.address, id)
+
+    # check position was added to positions mapping
+    expect = pos
+    actual = position.positions(pos_key)
+    assert expect == actual
+
+
+def test_positions_getter(position, bob):
+    owner = bob
+    id = 1
+
+    # add the position first
+    leverage = 5000000000000000000  # 5x
+    is_long = True
+    entry_price = 100000000000000000000  # 100
+    oi = 10000000000000000000  # 10
+    debt = 8000000000000000000  # 8
+    cost = 2000000000000000000  # 2
+
+    pos = (leverage, is_long, entry_price, oi, debt, cost)
+    position.set(owner, id, pos)
+
+    # check retrieved position is expected
+    expect = pos
+    actual = position.get(bob, id)
+    assert expect == actual

--- a/tests/markets/test_build.py
+++ b/tests/markets/test_build.py
@@ -84,8 +84,6 @@ def test_build_creates_position(market, feed, ovl, alice, oi, leverage,
     expect_oi_shares = int(oi * Decimal(1e18))
     expect_debt = int(debt * Decimal(1e18))
     expect_cost = int(collateral * Decimal(1e18))
-    expect_pos = (expect_leverage, expect_is_long, expect_entry_price,
-                  expect_oi_shares, expect_debt, expect_cost)
 
     # check position info
     expect_pos_key = get_position_key(alice.address, expect_pos_id)


### PR DESCRIPTION
Changes `Position.Info[] public positions` to

```
mapping(bytes32 => Position.Info) public positions;
uint256 private _totalPositions;
```

where the keys of the positions mapping are `keccak256(abi.encodePacked(owner, _totalPositions))`. `_totalPositions`, as the unique ID of position, is incremented every time a new position is built. `address owner` is the owner of the position.

This allows us to incorporate ownership while saving a bit of gas (~ 20k approximately).