### PR TITLE
Remove access control from factory

### DIFF
--- a/contracts/OverlayV1Factory.sol
+++ b/contracts/OverlayV1Factory.sol
@@ -9,10 +9,7 @@ import "./libraries/Risk.sol";
 import "./OverlayV1Token.sol";
 import "./OverlayV1Deployer.sol";
 
-contract OverlayV1Factory is AccessControlEnumerable {
-    bytes32 public constant ADMIN_ROLE = 0x00;
-    bytes32 public constant GOVERNOR_ROLE = keccak256("GOVERNOR");
-
+contract OverlayV1Factory {
     // risk param bounds
     uint256 public constant MIN_K = 4e8; // ~ 0.1 bps / 8 hr
     uint256 public constant MAX_K = 4e12; // ~ 1000 bps / 8 hr
@@ -105,14 +102,11 @@ contract OverlayV1Factory is AccessControlEnumerable {
 
     // governor modifier for governance sensitive functions
     modifier onlyGovernor() {
-        require(hasRole(GOVERNOR_ROLE, msg.sender), "OVLV1: !governor");
+        require(ovl.hasRole(ovl.GOVERNOR_ROLE(), msg.sender), "OVLV1: !governor");
         _;
     }
 
     constructor(address _ovl) {
-        _setupRole(ADMIN_ROLE, msg.sender);
-        _setupRole(GOVERNOR_ROLE, msg.sender);
-
         // set ovl
         ovl = OverlayV1Token(_ovl);
 

--- a/contracts/OverlayV1Factory.sol
+++ b/contracts/OverlayV1Factory.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.10;
 
-import "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
-
 import "./interfaces/IOverlayV1FeedFactory.sol";
 import "./libraries/Risk.sol";
 

--- a/contracts/OverlayV1Token.sol
+++ b/contracts/OverlayV1Token.sol
@@ -8,12 +8,14 @@ contract OverlayV1Token is AccessControlEnumerable, ERC20("Overlay", "OVL") {
     bytes32 public constant ADMIN_ROLE = 0x00;
     bytes32 public constant MINTER_ROLE = keccak256("MINTER");
     bytes32 public constant BURNER_ROLE = keccak256("BURNER");
+    bytes32 public constant GOVERNOR_ROLE = keccak256("GOVERNOR");
 
     constructor() {
         _setupRole(ADMIN_ROLE, msg.sender);
         _setupRole(MINTER_ROLE, msg.sender);
         _setRoleAdmin(MINTER_ROLE, ADMIN_ROLE);
         _setRoleAdmin(BURNER_ROLE, ADMIN_ROLE);
+        _setRoleAdmin(GOVERNOR_ROLE, ADMIN_ROLE);
     }
 
     modifier onlyMinter() {

--- a/tests/factories/market/conftest.py
+++ b/tests/factories/market/conftest.py
@@ -114,6 +114,9 @@ def create_factory(gov, request, ovl, feed_factory, feed_three):
         # grant market factory token admin role
         tok.grantRole(tok.ADMIN_ROLE(), factory, {"from": gov})
 
+        # grant gov the governor role on token to access factory methods
+        tok.grantRole(tok.GOVERNOR_ROLE(), gov, {"from": gov})
+
         # add the feed factory
         factory.addFeedFactory(feeds, {"from": gov})
 

--- a/tests/factories/market/test_conftest.py
+++ b/tests/factories/market/test_conftest.py
@@ -7,12 +7,11 @@ def test_factory_fixture(factory, feed_factory, feed_three, ovl, gov,
     assert factory.deployer() != "0x0000000000000000000000000000000000000000"
     assert deployer.factory() == factory
 
-    # check appropriate factory roles given to contract deployer
-    assert factory.hasRole(factory.ADMIN_ROLE(), gov) is True
-    assert factory.hasRole(factory.GOVERNOR_ROLE(), gov) is True
-
     # check factory has been given admin role on ovl token
     assert ovl.hasRole(ovl.ADMIN_ROLE(), factory) is True
+
+    # check gov has been given governance role on ovl token
+    assert ovl.hasRole(ovl.GOVERNOR_ROLE(), gov) is True
 
     # check feed factory has been added to registry
     assert factory.isFeedFactory(feed_factory) is True

--- a/tests/factories/market/test_deploy_market.py
+++ b/tests/factories/market/test_deploy_market.py
@@ -3,9 +3,6 @@ from brownie import chain, interface, reverts
 from collections import OrderedDict
 
 
-# TODO: fix for priceDriftUpperLimit addition, add deployer tests
-
-
 # NOTE: Use feed_one in successful create market test. Use feed_two for revert
 # tests. feed_three has already had a market deployed on it (market fixture)
 # Using isolation fixture given successfully deploy markets in some tests


### PR DESCRIPTION
Moves all access control functionality to `OverlayV1Token.sol`, removing access control logic from `OverlayV1Factory.sol`.

`GOVERNOR_ROLE` added to OVL token contract, with `onlyGovernor` modifier in factory contract checking `OverlayV1Token.hasRole(ovl.GOVERNOR_ROLE(), msg.sender)` for whether to revert.