### PR TITLE
Revise funding for burn

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,12 @@ The market contract tracks the current open interest for all outstanding positio
 ```
 library Position {
   struct Info {
-      uint120 oiShares; // initial open interest
+      uint120 notional; // initial notional = collateral * leverage
       uint120 debt; // debt
       bool isLong; // whether long or short
       bool liquidated; // whether has been liquidated
       uint256 entryPrice; // price received at entry
+      uint256 oiShares; // shares of aggregate open interest on side
   }
 }
 ```

--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -17,6 +17,8 @@ dependencies:
 compiler:
   solc:
     version: 0.8.10
+    optimizer:
+      runs: 800
     remappings:
       - "@openzeppelin=OpenZeppelin/openzeppelin-contracts@4.4.2"
       - "@uniswap/v3-core=Uniswap/v3-core@1.0.0"

--- a/contracts/OverlayV1Factory.sol
+++ b/contracts/OverlayV1Factory.sol
@@ -185,7 +185,6 @@ contract OverlayV1Factory is IOverlayV1Factory {
             params.capPayoff >= MIN_CAP_PAYOFF && params.capPayoff <= MAX_CAP_PAYOFF,
             "OVLV1: capPayoff out of bounds"
         );
-        // TODO: test
         require(
             params.capNotional >= MIN_CAP_NOTIONAL && params.capNotional <= MAX_CAP_NOTIONAL,
             "OVLV1: capNotional out of bounds"
@@ -282,7 +281,6 @@ contract OverlayV1Factory is IOverlayV1Factory {
     }
 
     /// @dev notional cap setter
-    // TODO: test
     function setCapNotional(address feed, uint256 capNotional) external onlyGovernor {
         require(
             capNotional >= MIN_CAP_NOTIONAL && capNotional <= MAX_CAP_NOTIONAL,

--- a/contracts/OverlayV1Factory.sol
+++ b/contracts/OverlayV1Factory.sol
@@ -20,8 +20,8 @@ contract OverlayV1Factory is IOverlayV1Factory {
     uint256 public constant MAX_DELTA = 2e16; // 2% (200 bps)
     uint256 public constant MIN_CAP_PAYOFF = 1e18; // 1x
     uint256 public constant MAX_CAP_PAYOFF = 1e19; // 10x
-    uint256 public constant MIN_CAP_OI = 0; // 0 OVL
-    uint256 public constant MAX_CAP_OI = 8e24; // 8,000,000 OVL (initial supply)
+    uint256 public constant MIN_CAP_NOTIONAL = 0; // 0 OVL
+    uint256 public constant MAX_CAP_NOTIONAL = 8e24; // 8,000,000 OVL (initial supply)
     uint256 public constant MIN_CAP_LEVERAGE = 1e18; // 1x
     uint256 public constant MAX_CAP_LEVERAGE = 2e19; // 20x
     uint256 public constant MIN_CIRCUIT_BREAKER_WINDOW = 86400; // 1 day
@@ -46,7 +46,7 @@ contract OverlayV1Factory is IOverlayV1Factory {
     event ImpactUpdated(address indexed user, address indexed market, uint256 lmbda);
     event SpreadUpdated(address indexed user, address indexed market, uint256 delta);
     event PayoffCapUpdated(address indexed user, address indexed market, uint256 capPayoff);
-    event OpenInterestCapUpdated(address indexed user, address indexed market, uint256 capOi);
+    event NotionalCapUpdated(address indexed user, address indexed market, uint256 capNotional);
     event LeverageCapUpdated(address indexed user, address indexed market, uint256 capLeverage);
     event CircuitBreakerWindowUpdated(
         address indexed user,
@@ -185,9 +185,10 @@ contract OverlayV1Factory is IOverlayV1Factory {
             params.capPayoff >= MIN_CAP_PAYOFF && params.capPayoff <= MAX_CAP_PAYOFF,
             "OVLV1: capPayoff out of bounds"
         );
+        // TODO: test
         require(
-            params.capOi >= MIN_CAP_OI && params.capOi <= MAX_CAP_OI,
-            "OVLV1: capOi out of bounds"
+            params.capNotional >= MIN_CAP_NOTIONAL && params.capNotional <= MAX_CAP_NOTIONAL,
+            "OVLV1: capNotional out of bounds"
         );
         require(
             params.capLeverage >= MIN_CAP_LEVERAGE && params.capLeverage <= MAX_CAP_LEVERAGE,
@@ -280,12 +281,16 @@ contract OverlayV1Factory is IOverlayV1Factory {
         emit PayoffCapUpdated(msg.sender, address(market), capPayoff);
     }
 
-    /// @dev oi cap setter
-    function setCapOi(address feed, uint256 capOi) external onlyGovernor {
-        require(capOi >= MIN_CAP_OI && capOi <= MAX_CAP_OI, "OVLV1: capOi out of bounds");
+    /// @dev notional cap setter
+    // TODO: test
+    function setCapNotional(address feed, uint256 capNotional) external onlyGovernor {
+        require(
+            capNotional >= MIN_CAP_NOTIONAL && capNotional <= MAX_CAP_NOTIONAL,
+            "OVLV1: capNotional out of bounds"
+        );
         OverlayV1Market market = OverlayV1Market(getMarket[feed]);
-        market.setCapOi(capOi);
-        emit OpenInterestCapUpdated(msg.sender, address(market), capOi);
+        market.setCapNotional(capNotional);
+        emit NotionalCapUpdated(msg.sender, address(market), capNotional);
     }
 
     /// @dev initial leverage cap setter

--- a/contracts/OverlayV1Factory.sol
+++ b/contracts/OverlayV1Factory.sol
@@ -14,7 +14,7 @@ contract OverlayV1Factory is IOverlayV1Factory {
     // risk param bounds
     uint256 public constant MIN_K = 4e8; // ~ 0.1 bps / 8 hr
     uint256 public constant MAX_K = 4e12; // ~ 1000 bps / 8 hr
-    uint256 public constant MIN_LMBDA = 1e17; // 0.1
+    uint256 public constant MIN_LMBDA = 1e16; // 0.01
     uint256 public constant MAX_LMBDA = 1e19; // 10
     uint256 public constant MIN_DELTA = 1e14; // 0.01% (1 bps)
     uint256 public constant MAX_DELTA = 2e16; // 2% (200 bps)
@@ -38,8 +38,8 @@ contract OverlayV1Factory is IOverlayV1Factory {
     uint256 public constant MAX_TRADING_FEE_RATE = 3e15; // 0.30% (30 bps)
     uint256 public constant MIN_MINIMUM_COLLATERAL = 1e12; // 1e-6 OVL
     uint256 public constant MAX_MINIMUM_COLLATERAL = 1e18; // 1 OVL
-    uint256 public constant MIN_PRICE_DRIFT_UPPER_LIMIT = 1e12; // 0.0001% per sec (0.01 bps/s)
-    uint256 public constant MAX_PRICE_DRIFT_UPPER_LIMIT = 1e16; // 1.00% per sec (100 bps/s)
+    uint256 public constant MIN_PRICE_DRIFT_UPPER_LIMIT = 1e12; // 0.01 bps/s
+    uint256 public constant MAX_PRICE_DRIFT_UPPER_LIMIT = 1e14; // 1 bps/s
 
     // events for risk param updates
     event FundingUpdated(address indexed user, address indexed market, uint256 k);

--- a/contracts/OverlayV1Market.sol
+++ b/contracts/OverlayV1Market.sol
@@ -477,8 +477,8 @@ contract OverlayV1Market is IOverlayV1Market {
         uint256 oiTotalBefore = oiOverweightBefore + oiUnderweightBefore;
         uint256 oiImbalanceBefore = oiOverweightBefore - oiUnderweightBefore;
 
-        // If no OI, no funding occurs. Handles div by zero case below
-        if (oiTotalBefore == 0) {
+        // If no OI or imbalance, no funding occurs. Handles div by zero case below
+        if (oiTotalBefore == 0 || oiImbalanceBefore == 0) {
             return (oiOverweightBefore, oiUnderweightBefore);
         }
 
@@ -591,7 +591,6 @@ contract OverlayV1Market is IOverlayV1Market {
 
     /// @dev Returns the open interest in number of contracts for a given notional
     /// @dev Uses mid(data, 0, 0) price to calculate oi: OI = Q / P
-    // TODO: test
     function oiFromNotional(Oracle.Data memory data, uint256 notional)
         public
         view
@@ -694,7 +693,7 @@ contract OverlayV1Market is IOverlayV1Market {
     }
 
     /// TODO: emergencyWithdraw(?): allows withdrawal of original collateral
-    /// TODO: without profit/loss if system in emergencyShutdown mode
+    /// TODO: without profit/loss if system in emergencyShutdown mode (factory level)
 
     /// @dev governance adjustable risk parameter setters
     /// @dev min/max bounds checks to risk params imposed at factory level

--- a/contracts/OverlayV1Market.sol
+++ b/contracts/OverlayV1Market.sol
@@ -512,9 +512,9 @@ contract OverlayV1Market is IOverlayV1Market {
 
     /// @dev bound on notional cap from circuit breaker
     /// @dev Three cases:
-    /// @dev 1. minted < 1x target amount over circuitBreakerWindow: return capOi
+    /// @dev 1. minted < 1x target amount over circuitBreakerWindow: return cap
     /// @dev 2. minted > 2x target amount over last circuitBreakerWindow: return 0
-    /// @dev 3. minted between 1x and 2x target amount: return capOi * (2 - minted/target)
+    /// @dev 3. minted between 1x and 2x target amount: return cap * (2 - minted/target)
     function circuitBreaker(Roller.Snapshot memory snapshot, uint256 cap)
         public
         view

--- a/contracts/OverlayV1Market.sol
+++ b/contracts/OverlayV1Market.sol
@@ -512,7 +512,6 @@ contract OverlayV1Market is IOverlayV1Market {
 
     /// @dev current notional cap with adjustments to lower
     /// @dev cap in the event market has printed a lot in recent past
-    // TODO: test
     function capNotionalAdjustedForCircuitBreaker(uint256 cap) public view returns (uint256) {
         // Adjust cap downward for circuit breaker. Use snapshotMinted
         // but transformed to account for decay in magnitude of minted since
@@ -548,7 +547,6 @@ contract OverlayV1Market is IOverlayV1Market {
 
     /// @dev current notional cap with adjustments to prevent
     /// @dev front-running trade and back-running trade
-    // TODO: test
     function capNotionalAdjustedForBounds(Oracle.Data memory data, uint256 cap)
         public
         view
@@ -566,13 +564,12 @@ contract OverlayV1Market is IOverlayV1Market {
 
     /// @dev bound on notional cap to mitigate front-running attack
     /// @dev bound = lmbda * reserveInOvl
-    // TODO: test
     function frontRunBound(Oracle.Data memory data) public view returns (uint256) {
         return lmbda.mulDown(data.reserveOverMicroWindow);
     }
 
     /// @dev bound on notional cap to mitigate back-running attack
-    /// @dev bound = macroWindow * reserveInOvl * 2 * delta
+    /// @dev bound = macroWindowInBlocks * reserveInOvl * 2 * delta
     function backRunBound(Oracle.Data memory data) public view returns (uint256) {
         // TODO: macroWindow should be in blocks in current spec. What to do here to be
         // futureproof vs having an average block time constant (BAD)
@@ -582,7 +579,6 @@ contract OverlayV1Market is IOverlayV1Market {
 
     /// @dev Transforms notional cap into cap on number of contracts (open interest)
     /// @dev Uses mid(data, 0, 0) price to calculate current open interest cap: C_OI = C_Q / P
-    /// TODO: test
     function capOi(Oracle.Data memory data, uint256 capNotionalAdjusted)
         public
         view

--- a/contracts/OverlayV1Market.sol
+++ b/contracts/OverlayV1Market.sol
@@ -185,13 +185,11 @@ contract OverlayV1Market is IOverlayV1Market {
             uint256 oiTotalSharesOnSide = isLong ? oiLongShares : oiShortShares;
 
             // check new total oi on side does not exceed capOi
-            // TODO: test
             oiTotalOnSide += oi;
             oiTotalSharesOnSide += oi;
             require(oiTotalOnSide <= oiFromNotional(data, capNotionalAdjusted), "OVLV1:oi>cap");
 
             // update total aggregate oi and oi shares
-            // TODO: test
             if (isLong) {
                 oiLong = oiTotalOnSide;
                 oiLongShares = oiTotalSharesOnSide;
@@ -264,7 +262,6 @@ contract OverlayV1Market is IOverlayV1Market {
         // where volume = oi / capOi
         // current cap only adjusted for bounds (no circuit breaker so traders
         // don't get stuck in a position)
-        // TODO: test and check
         uint256 price = pos.isLong
             ? bid(
                 data,
@@ -307,7 +304,6 @@ contract OverlayV1Market is IOverlayV1Market {
 
         // subtract unwound open interest from the side's aggregate oi value
         // and decrease number of oi shares issued
-        // TODO: test
         if (pos.isLong) {
             oiLong -= pos.oiCurrent(fraction, oiTotalOnSide, oiTotalSharesOnSide);
             oiLongShares -= pos.oiSharesCurrent(fraction);
@@ -317,10 +313,9 @@ contract OverlayV1Market is IOverlayV1Market {
         }
 
         // store the updated position info data
-        // TODO: test and check
         pos.notional -= uint120(pos.notionalInitial(fraction));
         pos.debt -= uint120(pos.debtCurrent(fraction));
-        pos.oiShares -= pos.oiSharesCurrent(fraction); // TODO: test
+        pos.oiShares -= pos.oiSharesCurrent(fraction);
         positions.set(msg.sender, positionId, pos);
 
         // emit unwind event
@@ -605,6 +600,7 @@ contract OverlayV1Market is IOverlayV1Market {
 
     /// @dev Returns the open interest in number of contracts for a given notional
     /// @dev Uses _midFromFeed(data) price to calculate oi: OI = Q / P
+    // TODO: fix potential rounding errors w div and large prices; move to Position lib
     function oiFromNotional(Oracle.Data memory data, uint256 notional)
         public
         view

--- a/contracts/OverlayV1Market.sol
+++ b/contracts/OverlayV1Market.sol
@@ -239,8 +239,6 @@ contract OverlayV1Market is IOverlayV1Market {
         // where volume = oi / capOi ~ (notional / P(t)) / (capNotional / P(t))
         // current cap only adjusted for bounds (no circuit breaker so traders
         // don't get stuck in a position)
-        //
-        // TODO: think through capOi vs capNotional
         // TODO: test and check
         uint256 price = pos.isLong
             ? bid(
@@ -334,10 +332,10 @@ contract OverlayV1Market is IOverlayV1Market {
         uint256 fraction = ONE;
 
         // longs get the bid and shorts get the ask on liquidate
-        // NOTE: liquidated position's oi should *not* add additional volume to roller
-        // NOTE: since market impact intended to mitigate front-running -- not relevant here
-        // NOTE: Use mid price without volume for liquidation (oracle price effectively) to
-        // NOTE: prevent market impact manipulation from causing unneccessary liquidations
+        // liquidated position's oi should *not* add additional volume to roller
+        // since market impact intended to mitigate front-running -- not relevant here
+        // Use mid price without volume for liquidation (oracle price effectively) to
+        // prevent market impact manipulation from causing unneccessary liquidations
         // TODO: think through mid price usage
         // TODO: test
         uint256 price = mid(data, 0, 0);
@@ -474,7 +472,6 @@ contract OverlayV1Market is IOverlayV1Market {
 
         // draw down the imbalance by factor of e**(-2*k*t)
         // but min to zero if pow = 2*k*t exceeds MAX_NATURAL_EXPONENT
-        // TODO: test
         uint256 fundingFactor;
         if (2 * k * timeElapsed < MAX_NATURAL_EXPONENT) {
             fundingFactor = INVERSE_EULER.powDown(2 * k * timeElapsed);
@@ -498,7 +495,6 @@ contract OverlayV1Market is IOverlayV1Market {
         // overweight pays underweight
         // use oiOver * oiUnder = invariant for oiUnderNow to avoid any
         // potential overflow reverts
-        // TODO: test
         uint256 oiOverweightNow = (oiTotalNow + oiImbalanceNow) / 2;
         uint256 oiUnderweightNow;
         if (oiOverweightNow != 0) {
@@ -716,7 +712,6 @@ contract OverlayV1Market is IOverlayV1Market {
         capPayoff = _capPayoff;
     }
 
-    // TODO: test
     function setCapNotional(uint256 _capNotional) external onlyFactory {
         capNotional = _capNotional;
     }

--- a/contracts/OverlayV1Market.sol
+++ b/contracts/OverlayV1Market.sol
@@ -304,18 +304,25 @@ contract OverlayV1Market is IOverlayV1Market {
 
         // subtract unwound open interest from the side's aggregate oi value
         // and decrease number of oi shares issued
+        // use Math.min to avoid reverts with rounding issues
         if (pos.isLong) {
-            oiLong -= pos.oiCurrent(fraction, oiTotalOnSide, oiTotalSharesOnSide);
-            oiLongShares -= pos.oiSharesCurrent(fraction);
+            oiLong -= Math.min(
+                oiLong,
+                pos.oiCurrent(fraction, oiTotalOnSide, oiTotalSharesOnSide)
+            );
+            oiLongShares -= Math.min(oiLongShares, pos.oiSharesCurrent(fraction));
         } else {
-            oiShort -= pos.oiCurrent(fraction, oiTotalOnSide, oiTotalSharesOnSide);
-            oiShortShares -= pos.oiSharesCurrent(fraction);
+            oiShort -= Math.min(
+                oiShort,
+                pos.oiCurrent(fraction, oiTotalOnSide, oiTotalSharesOnSide)
+            );
+            oiShortShares -= Math.min(oiShortShares, pos.oiSharesCurrent(fraction));
         }
 
         // store the updated position info data
-        pos.notional -= uint120(pos.notionalInitial(fraction));
-        pos.debt -= uint120(pos.debtCurrent(fraction));
-        pos.oiShares -= pos.oiSharesCurrent(fraction);
+        pos.notional -= uint120(Math.min(pos.notional, pos.notionalInitial(fraction)));
+        pos.debt -= uint120(Math.min(pos.debt, pos.debtCurrent(fraction)));
+        pos.oiShares -= Math.min(pos.oiShares, pos.oiSharesCurrent(fraction));
         positions.set(msg.sender, positionId, pos);
 
         // emit unwind event
@@ -389,13 +396,20 @@ contract OverlayV1Market is IOverlayV1Market {
 
         // subtract liquidated open interest from the side's aggregate oi value
         // and decrease number of oi shares issued
+        // use Math.min to avoid reverts with rounding issues
         // TODO: test
         if (pos.isLong) {
-            oiLong -= pos.oiCurrent(fraction, oiTotalOnSide, oiTotalSharesOnSide);
-            oiLongShares -= pos.oiSharesCurrent(fraction);
+            oiLong -= Math.min(
+                oiLong,
+                pos.oiCurrent(fraction, oiTotalOnSide, oiTotalSharesOnSide)
+            );
+            oiLongShares -= Math.min(oiLongShares, pos.oiSharesCurrent(fraction));
         } else {
-            oiShort -= pos.oiCurrent(fraction, oiTotalOnSide, oiTotalSharesOnSide);
-            oiShortShares -= pos.oiSharesCurrent(fraction);
+            oiShort -= Math.min(
+                oiShort,
+                pos.oiCurrent(fraction, oiTotalOnSide, oiTotalSharesOnSide)
+            );
+            oiShortShares -= Math.min(oiShortShares, pos.oiSharesCurrent(fraction));
         }
 
         // store the updated position info data. mark as liquidated

--- a/contracts/OverlayV1Market.sol
+++ b/contracts/OverlayV1Market.sol
@@ -208,7 +208,6 @@ contract OverlayV1Market is IOverlayV1Market {
                 entryPrice: price,
                 oiShares: oi
             });
-            // TODO: test
             require(
                 !pos.liquidatable(
                     oiTotalOnSide,
@@ -359,12 +358,8 @@ contract OverlayV1Market is IOverlayV1Market {
         // entire position should be liquidated
         uint256 fraction = ONE;
 
-        // longs get the bid and shorts get the ask on liquidate
-        // liquidated position's oi should *not* add additional volume to roller
-        // since market impact intended to mitigate front-running -- not relevant here
         // Use mid price without volume for liquidation (oracle price effectively) to
         // prevent market impact manipulation from causing unneccessary liquidations
-        // TODO: test
         uint256 price = _midFromFeed(data);
 
         // check position is liquidatable
@@ -397,7 +392,6 @@ contract OverlayV1Market is IOverlayV1Market {
         // subtract liquidated open interest from the side's aggregate oi value
         // and decrease number of oi shares issued
         // use Math.min to avoid reverts with rounding issues
-        // TODO: test
         if (pos.isLong) {
             oiLong -= Math.min(
                 oiLong,
@@ -413,10 +407,9 @@ contract OverlayV1Market is IOverlayV1Market {
         }
 
         // store the updated position info data. mark as liquidated
-        // TODO: test
         pos.notional = 0;
         pos.debt = 0;
-        pos.oiShares = 0; // TODO: test
+        pos.oiShares = 0;
         pos.liquidated = true;
         positions.set(owner, positionId, pos);
 

--- a/contracts/interfaces/IOverlayV1Factory.sol
+++ b/contracts/interfaces/IOverlayV1Factory.sol
@@ -24,9 +24,9 @@ interface IOverlayV1Factory {
 
     function MAX_CAP_PAYOFF() external view returns (uint256);
 
-    function MIN_CAP_OI() external view returns (uint256);
+    function MIN_CAP_NOTIONAL() external view returns (uint256);
 
-    function MAX_CAP_OI() external view returns (uint256);
+    function MAX_CAP_NOTIONAL() external view returns (uint256);
 
     function MIN_CAP_LEVERAGE() external view returns (uint256);
 
@@ -100,7 +100,7 @@ interface IOverlayV1Factory {
 
     function setCapPayoff(address feed, uint256 capPayoff) external;
 
-    function setCapOi(address feed, uint256 capOi) external;
+    function setCapNotional(address feed, uint256 capNotional) external;
 
     function setCapLeverage(address feed, uint256 capLeverage) external;
 

--- a/contracts/interfaces/IOverlayV1Market.sol
+++ b/contracts/interfaces/IOverlayV1Market.sol
@@ -85,11 +85,12 @@ interface IOverlayV1Market {
         external
         view
         returns (
-            uint120 oiShares_,
+            uint120 notional_,
             uint120 debt_,
             bool isLong_,
             bool liquidated_,
-            uint256 entryPrice_
+            uint256 entryPrice_,
+            uint256 oiShares_
         );
 
     // update related quantities
@@ -150,8 +151,11 @@ interface IOverlayV1Market {
     // bound on open interest cap to mitigate back-running attack
     function backRunBound(Oracle.Data memory data) external view returns (uint256);
 
-    // transforms notional cap into cap on number of contracts (open interest)
-    function capOi(Oracle.Data memory data, uint256 capNotional) external view returns (uint256);
+    // transforms notional into number of contracts (open interest)
+    function oiFromNotional(Oracle.Data memory data, uint256 notional)
+        external
+        view
+        returns (uint256);
 
     // bid price given oracle data and recent volume
     function bid(Oracle.Data memory data, uint256 volume) external view returns (uint256 bid_);

--- a/contracts/interfaces/IOverlayV1Market.sol
+++ b/contracts/interfaces/IOverlayV1Market.sol
@@ -23,7 +23,7 @@ interface IOverlayV1Market {
 
     function capPayoff() external view returns (uint256);
 
-    function capOi() external view returns (uint256);
+    function capNotional() external view returns (uint256);
 
     function capLeverage() external view returns (uint256);
 
@@ -127,9 +127,9 @@ interface IOverlayV1Market {
     // next position id
     function nextPositionId() external view returns (uint256);
 
-    // current open interest cap with adjustments for circuit breaker if market has
+    // current notional cap with adjustments for circuit breaker if market has
     // printed a lot in recent past
-    function capOiAdjustedForCircuitBreaker(uint256 cap) external view returns (uint256);
+    function capNotionalAdjustedForCircuitBreaker(uint256 cap) external view returns (uint256);
 
     // bound on open interest cap from circuit breaker
     function circuitBreaker(Roller.Snapshot memory snapshot, uint256 cap)
@@ -137,9 +137,9 @@ interface IOverlayV1Market {
         view
         returns (uint256);
 
-    // current open interest cap with adjustments to prevent front-running
+    // current notional cap with adjustments to prevent front-running
     // trade and back-running trade
-    function capOiAdjustedForBounds(Oracle.Data memory data, uint256 cap)
+    function capNotionalAdjustedForBounds(Oracle.Data memory data, uint256 cap)
         external
         view
         returns (uint256);
@@ -149,6 +149,9 @@ interface IOverlayV1Market {
 
     // bound on open interest cap to mitigate back-running attack
     function backRunBound(Oracle.Data memory data) external view returns (uint256);
+
+    // transforms notional cap into cap on number of contracts (open interest)
+    function capOi(Oracle.Data memory data, uint256 capNotional) external view returns (uint256);
 
     // bid price given oracle data and recent volume
     function bid(Oracle.Data memory data, uint256 volume) external view returns (uint256 bid_);
@@ -172,7 +175,7 @@ interface IOverlayV1Market {
 
     function setCapPayoff(uint256 _capPayoff) external;
 
-    function setCapOi(uint256 _capOi) external;
+    function setCapNotional(uint256 _capNotional) external;
 
     function setCapLeverage(uint256 _capLeverage) external;
 

--- a/contracts/libraries/Risk.sol
+++ b/contracts/libraries/Risk.sol
@@ -7,7 +7,7 @@ library Risk {
         uint256 lmbda; // market impact constant
         uint256 delta; // bid-ask static spread constant
         uint256 capPayoff; // payoff cap
-        uint256 capOi; // static oi cap
+        uint256 capNotional; // initial notional cap
         uint256 capLeverage; // initial leverage cap
         uint256 circuitBreakerWindow; // trailing window for circuit breaker
         uint256 circuitBreakerMintTarget; // target worst case inflation rate over trailing window

--- a/contracts/mocks/PositionMock.sol
+++ b/contracts/mocks/PositionMock.sol
@@ -71,7 +71,11 @@ contract PositionMock {
         return pos.oiCurrent(fraction, oiTotalOnSide, oiTotalSharesOnSide);
     }
 
-    function debtCurrent(Position.Info memory pos, uint256 fraction) external view returns (uint256) {
+    function debtCurrent(Position.Info memory pos, uint256 fraction)
+        external
+        view
+        returns (uint256)
+    {
         return pos.debtCurrent(fraction);
     }
 

--- a/contracts/mocks/PositionMock.sol
+++ b/contracts/mocks/PositionMock.sol
@@ -86,7 +86,7 @@ contract PositionMock {
         return pos.value(fraction, totalOi, totalOiShares, currentPrice, capPayoff);
     }
 
-    function notional(
+    function notionalCurrent(
         Position.Info memory pos,
         uint256 fraction,
         uint256 totalOi,
@@ -94,7 +94,7 @@ contract PositionMock {
         uint256 currentPrice,
         uint256 capPayoff
     ) external view returns (uint256) {
-        return pos.notional(fraction, totalOi, totalOiShares, currentPrice, capPayoff);
+        return pos.notionalCurrent(fraction, totalOi, totalOiShares, currentPrice, capPayoff);
     }
 
     function tradingFee(

--- a/contracts/mocks/PositionMock.sol
+++ b/contracts/mocks/PositionMock.sol
@@ -77,39 +77,46 @@ contract PositionMock {
     function oiCurrent(
         Position.Info memory pos,
         uint256 fraction,
-        uint256 totalOi,
-        uint256 totalOiShares
+        uint256 oiTotalOnSide,
+        uint256 oiTotalSharesOnSide
     ) external view returns (uint256) {
-        return pos.oiCurrent(fraction, totalOi, totalOiShares);
+        return pos.oiCurrent(fraction, oiTotalOnSide, oiTotalSharesOnSide);
     }
 
     function value(
         Position.Info memory pos,
         uint256 fraction,
-        uint256 totalOi,
-        uint256 totalOiShares,
+        uint256 oiTotalOnSide,
+        uint256 oiTotalSharesOnSide,
         uint256 currentPrice,
         uint256 capPayoff
     ) external view returns (uint256) {
-        return pos.value(fraction, totalOi, totalOiShares, currentPrice, capPayoff);
+        return pos.value(fraction, oiTotalOnSide, oiTotalSharesOnSide, currentPrice, capPayoff);
     }
 
     function notionalCurrent(
         Position.Info memory pos,
         uint256 fraction,
-        uint256 totalOi,
-        uint256 totalOiShares,
+        uint256 oiTotalOnSide,
+        uint256 oiTotalSharesOnSide,
         uint256 currentPrice,
         uint256 capPayoff
     ) external view returns (uint256) {
-        return pos.notionalCurrent(fraction, totalOi, totalOiShares, currentPrice, capPayoff);
+        return
+            pos.notionalCurrent(
+                fraction,
+                oiTotalOnSide,
+                oiTotalSharesOnSide,
+                currentPrice,
+                capPayoff
+            );
     }
 
     function tradingFee(
         Position.Info memory pos,
         uint256 fraction,
-        uint256 totalOi,
-        uint256 totalOiShares,
+        uint256 oiTotalOnSide,
+        uint256 oiTotalSharesOnSide,
         uint256 currentPrice,
         uint256 capPayoff,
         uint256 tradingFeeRate
@@ -117,8 +124,8 @@ contract PositionMock {
         return
             pos.tradingFee(
                 fraction,
-                totalOi,
-                totalOiShares,
+                oiTotalOnSide,
+                oiTotalSharesOnSide,
                 currentPrice,
                 capPayoff,
                 tradingFeeRate
@@ -127,16 +134,16 @@ contract PositionMock {
 
     function liquidatable(
         Position.Info memory pos,
-        uint256 totalOi,
-        uint256 totalOiShares,
+        uint256 oiTotalOnSide,
+        uint256 oiTotalSharesOnSide,
         uint256 currentPrice,
         uint256 capPayoff,
         uint256 maintenanceMarginFraction
     ) external view returns (bool) {
         return
             pos.liquidatable(
-                totalOi,
-                totalOiShares,
+                oiTotalOnSide,
+                oiTotalSharesOnSide,
                 currentPrice,
                 capPayoff,
                 maintenanceMarginFraction
@@ -145,10 +152,10 @@ contract PositionMock {
 
     function liquidationPrice(
         Position.Info memory pos,
-        uint256 totalOi,
-        uint256 totalOiShares,
+        uint256 oiTotalOnSide,
+        uint256 oiTotalSharesOnSide,
         uint256 maintenanceMarginFraction
     ) external view returns (uint256) {
-        return pos.liquidationPrice(totalOi, totalOiShares, maintenanceMarginFraction);
+        return pos.liquidationPrice(oiTotalOnSide, oiTotalSharesOnSide, maintenanceMarginFraction);
     }
 }

--- a/contracts/mocks/PositionMock.sol
+++ b/contracts/mocks/PositionMock.sol
@@ -38,20 +38,12 @@ contract PositionMock {
                         POSITION CALC FUNCTIONS
     //////////////////////////////////////////////////////////////*/
 
-    function oiSharesCurrent(Position.Info memory pos, uint256 fraction)
+    function notionalInitial(Position.Info memory pos, uint256 fraction)
         external
         view
         returns (uint256)
     {
-        return pos.oiSharesCurrent(fraction);
-    }
-
-    function debtCurrent(Position.Info memory pos, uint256 fraction)
-        external
-        view
-        returns (uint256)
-    {
-        return pos.debtCurrent(fraction);
+        return pos.notionalInitial(fraction);
     }
 
     function oiInitial(Position.Info memory pos, uint256 fraction)
@@ -62,16 +54,12 @@ contract PositionMock {
         return pos.oiInitial(fraction);
     }
 
-    function notionalInitial(Position.Info memory pos, uint256 fraction)
+    function oiSharesCurrent(Position.Info memory pos, uint256 fraction)
         external
         view
         returns (uint256)
     {
-        return pos.notionalInitial(fraction);
-    }
-
-    function cost(Position.Info memory pos, uint256 fraction) external view returns (uint256) {
-        return pos.cost(fraction);
+        return pos.oiSharesCurrent(fraction);
     }
 
     function oiCurrent(
@@ -81,6 +69,14 @@ contract PositionMock {
         uint256 oiTotalSharesOnSide
     ) external view returns (uint256) {
         return pos.oiCurrent(fraction, oiTotalOnSide, oiTotalSharesOnSide);
+    }
+
+    function debtCurrent(Position.Info memory pos, uint256 fraction) external view returns (uint256) {
+        return pos.debtCurrent(fraction);
+    }
+
+    function cost(Position.Info memory pos, uint256 fraction) external view returns (uint256) {
+        return pos.cost(fraction);
     }
 
     function value(
@@ -94,7 +90,7 @@ contract PositionMock {
         return pos.value(fraction, oiTotalOnSide, oiTotalSharesOnSide, currentPrice, capPayoff);
     }
 
-    function notionalCurrent(
+    function notionalWithPnl(
         Position.Info memory pos,
         uint256 fraction,
         uint256 oiTotalOnSide,
@@ -103,7 +99,7 @@ contract PositionMock {
         uint256 capPayoff
     ) external view returns (uint256) {
         return
-            pos.notionalCurrent(
+            pos.notionalWithPnl(
                 fraction,
                 oiTotalOnSide,
                 oiTotalSharesOnSide,

--- a/contracts/mocks/PositionMock.sol
+++ b/contracts/mocks/PositionMock.sol
@@ -62,6 +62,14 @@ contract PositionMock {
         return pos.oiInitial(fraction);
     }
 
+    function notionalInitial(Position.Info memory pos, uint256 fraction)
+        external
+        view
+        returns (uint256)
+    {
+        return pos.notionalInitial(fraction);
+    }
+
     function cost(Position.Info memory pos, uint256 fraction) external view returns (uint256) {
         return pos.cost(fraction);
     }

--- a/tests/deployers/market/test_deploy.py
+++ b/tests/deployers/market/test_deploy.py
@@ -7,7 +7,7 @@ def test_deploy_creates_market(deployer, ovl, feed, factory):
     lmbda = 1000000000000000000
     delta = 2500000000000000
     cap_payoff = 5000000000000000000
-    cap_oi = 800000000000000000000000
+    cap_notional = 800000000000000000000000
     cap_leverage = 5000000000000000000
     circuit_breaker_window = 2592000
     circuit_breaker_mint_target = 66670000000000000000000
@@ -18,7 +18,7 @@ def test_deploy_creates_market(deployer, ovl, feed, factory):
     min_collateral = 100000000000000
     price_drift_upper_limit = 100000000000000
 
-    params = (k, lmbda, delta, cap_payoff, cap_oi, cap_leverage,
+    params = (k, lmbda, delta, cap_payoff, cap_notional, cap_leverage,
               circuit_breaker_window, circuit_breaker_mint_target,
               maintenance_margin_fraction, maintenance_margin_burn_rate,
               liquidation_fee_rate, trading_fee_rate, min_collateral,
@@ -39,7 +39,7 @@ def test_deploy_creates_market(deployer, ovl, feed, factory):
     assert market.lmbda() == lmbda
     assert market.delta() == delta
     assert market.capPayoff() == cap_payoff
-    assert market.capOi() == cap_oi
+    assert market.capNotional() == cap_notional
     assert market.capLeverage() == cap_leverage
     assert market.circuitBreakerWindow() == circuit_breaker_window
     assert market.circuitBreakerMintTarget() == circuit_breaker_mint_target
@@ -57,7 +57,7 @@ def test_deploy_reverts_when_not_factory(deployer, ovl, feed, rando):
     lmbda = 1000000000000000000
     delta = 2500000000000000
     cap_payoff = 5000000000000000000
-    cap_oi = 800000000000000000000000
+    cap_notional = 800000000000000000000000
     cap_leverage = 5000000000000000000
     circuit_breaker_window = 2592000
     circuit_breaker_mint_target = 66670000000000000000000
@@ -68,7 +68,7 @@ def test_deploy_reverts_when_not_factory(deployer, ovl, feed, rando):
     min_collateral = 100000000000000
     price_drift_upper_limit = 100000000000000
 
-    params = (k, lmbda, delta, cap_payoff, cap_oi, cap_leverage,
+    params = (k, lmbda, delta, cap_payoff, cap_notional, cap_leverage,
               circuit_breaker_window, circuit_breaker_mint_target,
               maintenance_margin_fraction, maintenance_margin_burn_rate,
               liquidation_fee_rate, trading_fee_rate, min_collateral,

--- a/tests/factories/market/conftest.py
+++ b/tests/factories/market/conftest.py
@@ -131,7 +131,7 @@ def create_factory(gov, fee_recipient, request, ovl, feed_factory, feed_three):
         lmbda = 1000000000000000000
         delta = 2500000000000000
         cap_payoff = 5000000000000000000
-        cap_oi = 800000000000000000000000
+        cap_notional = 800000000000000000000000
         cap_leverage = 5000000000000000000
         circuit_breaker_window = 2592000  # 30d
         circuit_breaker_mint_target = 66670000000000000000000  # 10% per year
@@ -142,7 +142,7 @@ def create_factory(gov, fee_recipient, request, ovl, feed_factory, feed_three):
         min_collateral = 100000000000000
         price_drift_upper_limit = 100000000000000  # 0.01% per sec
 
-        params = (k, lmbda, delta, cap_payoff, cap_oi, cap_leverage,
+        params = (k, lmbda, delta, cap_payoff, cap_notional, cap_leverage,
                   circuit_breaker_window, circuit_breaker_mint_target,
                   maintenance, maintenance_burn, liquidation_fee, trade_fee,
                   min_collateral, price_drift_upper_limit)

--- a/tests/factories/market/test_conftest.py
+++ b/tests/factories/market/test_conftest.py
@@ -46,7 +46,7 @@ def test_market_fixture(market, factory, feed_three, ovl, gov):
     assert market.lmbda() == 1000000000000000000
     assert market.delta() == 2500000000000000
     assert market.capPayoff() == 5000000000000000000
-    assert market.capOi() == 800000000000000000000000
+    assert market.capNotional() == 800000000000000000000000
     assert market.capLeverage() == 5000000000000000000
     assert market.circuitBreakerWindow() == 2592000
     assert market.circuitBreakerMintTarget() == 66670000000000000000000

--- a/tests/factories/market/test_deploy_market.py
+++ b/tests/factories/market/test_deploy_market.py
@@ -23,7 +23,7 @@ def test_deploy_market_creates_market(factory, feed_factory, feed_one, ovl,
     expect_lmbda = 1000000000000000000
     expect_delta = 2500000000000000
     expect_cap_payoff = 5000000000000000000
-    expect_cap_oi = 800000000000000000000000
+    expect_cap_notional = 800000000000000000000000
     expect_cap_leverage = 5000000000000000000
     expect_circuit_breaker_window = 2592000
     expect_circuit_breaker_mint_target = 66670000000000000000000
@@ -35,7 +35,7 @@ def test_deploy_market_creates_market(factory, feed_factory, feed_one, ovl,
     expect_price_drift_upper_limit = 100000000000000
 
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -85,7 +85,7 @@ def test_deploy_market_creates_market(factory, feed_factory, feed_one, ovl,
     assert market_contract.lmbda() == expect_lmbda
     assert market_contract.delta() == expect_delta
     assert market_contract.capPayoff() == expect_cap_payoff
-    assert market_contract.capOi() == expect_cap_oi
+    assert market_contract.capNotional() == expect_cap_notional
     assert market_contract.capLeverage() == expect_cap_leverage
     assert market_contract.maintenanceMarginFraction() \
         == expect_maintenance_margin_fraction
@@ -114,7 +114,7 @@ def test_deploy_market_reverts_when_not_gov(factory, feed_factory, feed_two,
     expect_lmbda = 1000000000000000000
     expect_delta = 2500000000000000
     expect_cap_payoff = 5000000000000000000
-    expect_cap_oi = 800000000000000000000000
+    expect_cap_notional = 800000000000000000000000
     expect_cap_leverage = 5000000000000000000
     expect_circuit_breaker_window = 2592000
     expect_circuit_breaker_mint_target = 66670000000000000000000
@@ -126,7 +126,7 @@ def test_deploy_market_reverts_when_not_gov(factory, feed_factory, feed_two,
     expect_price_drift_upper_limit = 100000000000000
 
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -161,7 +161,7 @@ def test_deploy_market_reverts_when_market_already_exists(factory,
     expect_lmbda = 1000000000000000000
     expect_delta = 2500000000000000
     expect_cap_payoff = 5000000000000000000
-    expect_cap_oi = 800000000000000000000000
+    expect_cap_notional = 800000000000000000000000
     expect_cap_leverage = 5000000000000000000
     expect_circuit_breaker_window = 2592000
     expect_circuit_breaker_mint_target = 66670000000000000000000
@@ -173,7 +173,7 @@ def test_deploy_market_reverts_when_market_already_exists(factory,
     expect_price_drift_upper_limit = 100000000000000
 
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -204,7 +204,7 @@ def test_deploy_market_reverts_when_feed_factory_not_supported(factory, rando,
     expect_lmbda = 1000000000000000000
     expect_delta = 2500000000000000
     expect_cap_payoff = 5000000000000000000
-    expect_cap_oi = 800000000000000000000000
+    expect_cap_notional = 800000000000000000000000
     expect_cap_leverage = 5000000000000000000
     expect_circuit_breaker_window = 2592000
     expect_circuit_breaker_mint_target = 66670000000000000000000
@@ -216,7 +216,7 @@ def test_deploy_market_reverts_when_feed_factory_not_supported(factory, rando,
     expect_price_drift_upper_limit = 100000000000000
 
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -245,7 +245,7 @@ def test_deploy_market_reverts_when_feed_does_not_exist(factory, feed_factory,
     expect_lmbda = 1000000000000000000
     expect_delta = 2500000000000000
     expect_cap_payoff = 5000000000000000000
-    expect_cap_oi = 800000000000000000000000
+    expect_cap_notional = 800000000000000000000000
     expect_cap_leverage = 5000000000000000000
     expect_circuit_breaker_window = 2592000
     expect_circuit_breaker_mint_target = 66670000000000000000000
@@ -257,7 +257,7 @@ def test_deploy_market_reverts_when_feed_does_not_exist(factory, feed_factory,
     expect_price_drift_upper_limit = 100000000000000
 
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -288,7 +288,7 @@ def test_deploy_market_reverts_when_k_less_than_min(factory, feed_factory,
     expect_lmbda = 1000000000000000000
     expect_delta = 2500000000000000
     expect_cap_payoff = 5000000000000000000
-    expect_cap_oi = 800000000000000000000000
+    expect_cap_notional = 800000000000000000000000
     expect_cap_leverage = 5000000000000000000
     expect_circuit_breaker_window = 2592000
     expect_circuit_breaker_mint_target = 66670000000000000000000
@@ -302,7 +302,7 @@ def test_deploy_market_reverts_when_k_less_than_min(factory, feed_factory,
     # check can't deploy with k less than min
     expect_k = factory.MIN_K() - 1
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -321,7 +321,7 @@ def test_deploy_market_reverts_when_k_less_than_min(factory, feed_factory,
     # check deploys with k equal to min
     expect_k = factory.MIN_K()
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -347,7 +347,7 @@ def test_deploy_market_reverts_when_k_greater_than_max(factory, feed_factory,
     expect_lmbda = 1000000000000000000
     expect_delta = 2500000000000000
     expect_cap_payoff = 5000000000000000000
-    expect_cap_oi = 800000000000000000000000
+    expect_cap_notional = 800000000000000000000000
     expect_cap_leverage = 5000000000000000000
     expect_circuit_breaker_window = 2592000
     expect_circuit_breaker_mint_target = 66670000000000000000000
@@ -361,7 +361,7 @@ def test_deploy_market_reverts_when_k_greater_than_max(factory, feed_factory,
     # check can't deploy with k greater than max
     expect_k = factory.MAX_K() + 1
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -380,7 +380,7 @@ def test_deploy_market_reverts_when_k_greater_than_max(factory, feed_factory,
     # check deploys with k equal to max
     expect_k = factory.MAX_K()
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -407,7 +407,7 @@ def test_deploy_market_reverts_when_lmbda_less_than_min(factory, feed_factory,
     expect_k = 1220000000000
     expect_delta = 2500000000000000
     expect_cap_payoff = 5000000000000000000
-    expect_cap_oi = 800000000000000000000000
+    expect_cap_notional = 800000000000000000000000
     expect_cap_leverage = 5000000000000000000
     expect_circuit_breaker_window = 2592000
     expect_circuit_breaker_mint_target = 66670000000000000000000
@@ -421,7 +421,7 @@ def test_deploy_market_reverts_when_lmbda_less_than_min(factory, feed_factory,
     # check can't deploy with lmbda less than min
     expect_lmbda = factory.MIN_LMBDA() - 1
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -440,7 +440,7 @@ def test_deploy_market_reverts_when_lmbda_less_than_min(factory, feed_factory,
     # check deploys with lmbda equal to min
     expect_lmbda = factory.MIN_LMBDA()
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -467,7 +467,7 @@ def test_deploy_market_reverts_when_lmbda_greater_than_max(factory,
     expect_k = 1220000000000
     expect_delta = 2500000000000000
     expect_cap_payoff = 5000000000000000000
-    expect_cap_oi = 800000000000000000000000
+    expect_cap_notional = 800000000000000000000000
     expect_cap_leverage = 5000000000000000000
     expect_circuit_breaker_window = 2592000
     expect_circuit_breaker_mint_target = 66670000000000000000000
@@ -481,7 +481,7 @@ def test_deploy_market_reverts_when_lmbda_greater_than_max(factory,
     # check can't deploy with lmbda greater than max
     expect_lmbda = factory.MAX_LMBDA() + 1
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -500,7 +500,7 @@ def test_deploy_market_reverts_when_lmbda_greater_than_max(factory,
     # check deploys with lmbda equal to max
     expect_lmbda = factory.MAX_LMBDA()
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -527,7 +527,7 @@ def test_deploy_market_reverts_when_delta_less_than_min(factory, feed_factory,
     expect_k = 1220000000000
     expect_lmbda = 1000000000000000000
     expect_cap_payoff = 5000000000000000000
-    expect_cap_oi = 800000000000000000000000
+    expect_cap_notional = 800000000000000000000000
     expect_cap_leverage = 5000000000000000000
     expect_circuit_breaker_window = 2592000
     expect_circuit_breaker_mint_target = 66670000000000000000000
@@ -541,7 +541,7 @@ def test_deploy_market_reverts_when_delta_less_than_min(factory, feed_factory,
     # check can't deploy with delta less than min
     expect_delta = factory.MIN_DELTA() - 1
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -560,7 +560,7 @@ def test_deploy_market_reverts_when_delta_less_than_min(factory, feed_factory,
     # check deploys with delta equal to min
     expect_delta = factory.MIN_DELTA()
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -587,7 +587,7 @@ def test_deploy_market_reverts_when_delta_greater_than_max(factory,
     expect_k = 1220000000000
     expect_lmbda = 1000000000000000000
     expect_cap_payoff = 5000000000000000000
-    expect_cap_oi = 800000000000000000000000
+    expect_cap_notional = 800000000000000000000000
     expect_cap_leverage = 5000000000000000000
     expect_circuit_breaker_window = 2592000
     expect_circuit_breaker_mint_target = 66670000000000000000000
@@ -601,7 +601,7 @@ def test_deploy_market_reverts_when_delta_greater_than_max(factory,
     # check can't deploy with delta greater than max
     expect_delta = factory.MAX_DELTA() + 1
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -620,7 +620,7 @@ def test_deploy_market_reverts_when_delta_greater_than_max(factory,
     # check deploys with delta equal to max
     expect_delta = factory.MAX_DELTA()
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -651,7 +651,7 @@ def test_deploy_market_reverts_when_cap_payoff_less_than_min(
     expect_k = 1220000000000
     expect_lmbda = 1000000000000000000
     expect_delta = 2500000000000000
-    expect_cap_oi = 800000000000000000000000
+    expect_cap_notional = 800000000000000000000000
     expect_cap_leverage = 5000000000000000000
     expect_circuit_breaker_window = 2592000
     expect_circuit_breaker_mint_target = 66670000000000000000000
@@ -665,7 +665,7 @@ def test_deploy_market_reverts_when_cap_payoff_less_than_min(
     # check can't deploy with capPayoff less than min
     expect_cap_payoff = factory.MIN_CAP_PAYOFF() - 1
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -684,7 +684,7 @@ def test_deploy_market_reverts_when_cap_payoff_less_than_min(
     # check deploys with capPayoff equal to min
     expect_cap_payoff = factory.MIN_CAP_PAYOFF()
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -714,7 +714,7 @@ def test_deploy_market_reverts_when_cap_payoff_greater_than_max(
     expect_k = 1220000000000
     expect_lmbda = 1000000000000000000
     expect_delta = 2500000000000000
-    expect_cap_oi = 800000000000000000000000
+    expect_cap_notional = 800000000000000000000000
     expect_cap_leverage = 5000000000000000000
     expect_circuit_breaker_window = 2592000
     expect_circuit_breaker_mint_target = 66670000000000000000000
@@ -728,7 +728,7 @@ def test_deploy_market_reverts_when_cap_payoff_greater_than_max(
     # check can't deploy with capPayoff greater than max
     expect_cap_payoff = factory.MAX_CAP_PAYOFF() + 1
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -747,7 +747,7 @@ def test_deploy_market_reverts_when_cap_payoff_greater_than_max(
     # check deploys with capPayoff equal to max
     expect_cap_payoff = factory.MAX_CAP_PAYOFF()
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -763,9 +763,9 @@ def test_deploy_market_reverts_when_cap_payoff_greater_than_max(
     )
 
 
-# capOi tests
-# NOTE: no cap_oi_less_than_min test because MIN_CAP_OI is zero
-def test_deploy_market_reverts_when_cap_oi_greater_than_max(
+# capNotional tests
+# NOTE: no cap_notional_less_than_min test because MIN_CAP_NOTIONAL is zero
+def test_deploy_market_reverts_when_cap_notional_greater_than_max(
     factory,
     feed_factory,
     feed_one,
@@ -790,10 +790,10 @@ def test_deploy_market_reverts_when_cap_oi_greater_than_max(
     expect_min_collateral = 100000000000000
     expect_price_drift_upper_limit = 100000000000000
 
-    # check can't deploy with capOi greater than max
-    expect_cap_oi = factory.MAX_CAP_OI() + 1
+    # check can't deploy with capNotional greater than max
+    expect_cap_notional = factory.MAX_CAP_NOTIONAL() + 1
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -801,7 +801,7 @@ def test_deploy_market_reverts_when_cap_oi_greater_than_max(
                      expect_liquidation_fee_rate,
                      expect_trading_fee_rate, expect_min_collateral,
                      expect_price_drift_upper_limit)
-    with reverts("OVLV1: capOi out of bounds"):
+    with reverts("OVLV1: capNotional out of bounds"):
         _ = factory.deployMarket(
             expect_feed_factory,
             expect_feed,
@@ -809,10 +809,10 @@ def test_deploy_market_reverts_when_cap_oi_greater_than_max(
             {"from": gov}
         )
 
-    # check deploys with capOi equal to max
-    expect_cap_oi = factory.MAX_CAP_OI()
+    # check deploys with capNotional equal to max
+    expect_cap_notional = factory.MAX_CAP_NOTIONAL()
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -843,7 +843,7 @@ def test_deploy_market_reverts_when_cap_leverage_less_than_min(
     expect_k = 1220000000000
     expect_lmbda = 1000000000000000000
     expect_delta = 2500000000000000
-    expect_cap_oi = 800000000000000000000000
+    expect_cap_notional = 800000000000000000000000
     expect_cap_payoff = 5000000000000000000
     expect_circuit_breaker_window = 2592000
     expect_circuit_breaker_mint_target = 66670000000000000000000
@@ -857,7 +857,7 @@ def test_deploy_market_reverts_when_cap_leverage_less_than_min(
     # check can't deploy with capLeverage less than min
     expect_cap_leverage = factory.MIN_CAP_LEVERAGE() - 1
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -876,7 +876,7 @@ def test_deploy_market_reverts_when_cap_leverage_less_than_min(
     # check deploys with capLeverage equal to min
     expect_cap_leverage = factory.MIN_CAP_LEVERAGE()
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -906,7 +906,7 @@ def test_deploy_market_reverts_when_cap_leverage_greater_than_max(
     expect_k = 1220000000000
     expect_lmbda = 1000000000000000000
     expect_delta = 2500000000000000
-    expect_cap_oi = 800000000000000000000000
+    expect_cap_notional = 800000000000000000000000
     expect_cap_payoff = 5000000000000000000
     expect_circuit_breaker_window = 2592000
     expect_circuit_breaker_mint_target = 66670000000000000000000
@@ -923,7 +923,7 @@ def test_deploy_market_reverts_when_cap_leverage_greater_than_max(
     # check can't deploy with capLeverage greater than max
     expect_cap_leverage = factory.MAX_CAP_LEVERAGE() + 1
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -942,7 +942,7 @@ def test_deploy_market_reverts_when_cap_leverage_greater_than_max(
     # check deploys with capLeverage equal to max
     expect_cap_leverage = factory.MAX_CAP_LEVERAGE()
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -973,7 +973,7 @@ def test_deploy_market_reverts_when_circuit_breaker_window_less_than_min(
     expect_k = 1220000000000
     expect_lmbda = 1000000000000000000
     expect_delta = 2500000000000000
-    expect_cap_oi = 800000000000000000000000
+    expect_cap_notional = 800000000000000000000000
     expect_cap_payoff = 5000000000000000000
     expect_cap_leverage = 5000000000000000000
     expect_circuit_breaker_mint_target = 66670000000000000000000
@@ -987,7 +987,7 @@ def test_deploy_market_reverts_when_circuit_breaker_window_less_than_min(
     # check can't deploy with circuitBreakerWindow less than min
     expect_circuit_breaker_window = factory.MIN_CIRCUIT_BREAKER_WINDOW() - 1
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -1006,7 +1006,7 @@ def test_deploy_market_reverts_when_circuit_breaker_window_less_than_min(
     # check deploys with circuitBreakerWindow equal to min
     expect_circuit_breaker_window = factory.MIN_CIRCUIT_BREAKER_WINDOW()
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -1036,7 +1036,7 @@ def test_deploy_market_reverts_when_circuit_breaker_window_greater_than_max(
     expect_k = 1220000000000
     expect_lmbda = 1000000000000000000
     expect_delta = 2500000000000000
-    expect_cap_oi = 800000000000000000000000
+    expect_cap_notional = 800000000000000000000000
     expect_cap_payoff = 5000000000000000000
     expect_cap_leverage = 5000000000000000000
     expect_circuit_breaker_mint_target = 66670000000000000000000
@@ -1050,7 +1050,7 @@ def test_deploy_market_reverts_when_circuit_breaker_window_greater_than_max(
     # check can't deploy with circuitBreakerWindow greater than max
     expect_circuit_breaker_window = factory.MAX_CIRCUIT_BREAKER_WINDOW() + 1
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -1069,7 +1069,7 @@ def test_deploy_market_reverts_when_circuit_breaker_window_greater_than_max(
     # check deploys with circuitBreakerWindow equal to max
     expect_circuit_breaker_window = factory.MAX_CIRCUIT_BREAKER_WINDOW()
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -1100,7 +1100,7 @@ def test_deploy_market_reverts_when_circuit_breaker_target_greater_than_max(
     expect_k = 1220000000000
     expect_lmbda = 1000000000000000000
     expect_delta = 2500000000000000
-    expect_cap_oi = 800000000000000000000000
+    expect_cap_notional = 800000000000000000000000
     expect_cap_payoff = 5000000000000000000
     expect_cap_leverage = 5000000000000000000
     expect_circuit_breaker_window = 2592000
@@ -1115,7 +1115,7 @@ def test_deploy_market_reverts_when_circuit_breaker_target_greater_than_max(
     expect_circuit_breaker_mint_target = \
         factory.MAX_CIRCUIT_BREAKER_MINT_TARGET() + 1
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -1135,7 +1135,7 @@ def test_deploy_market_reverts_when_circuit_breaker_target_greater_than_max(
     expect_circuit_breaker_mint_target = \
         factory.MAX_CIRCUIT_BREAKER_MINT_TARGET()
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -1166,7 +1166,7 @@ def test_deploy_market_reverts_when_maintenance_margin_less_than_min(
     expect_k = 1220000000000
     expect_lmbda = 1000000000000000000
     expect_delta = 2500000000000000
-    expect_cap_oi = 800000000000000000000000
+    expect_cap_notional = 800000000000000000000000
     expect_cap_payoff = 5000000000000000000
     expect_cap_leverage = 5000000000000000000
     expect_circuit_breaker_window = 2592000
@@ -1181,7 +1181,7 @@ def test_deploy_market_reverts_when_maintenance_margin_less_than_min(
     expect_maintenance_margin_fraction = \
         factory.MIN_MAINTENANCE_MARGIN_FRACTION() - 1
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -1201,7 +1201,7 @@ def test_deploy_market_reverts_when_maintenance_margin_less_than_min(
     expect_maintenance_margin_fraction = \
         factory.MIN_MAINTENANCE_MARGIN_FRACTION()
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -1231,7 +1231,7 @@ def test_deploy_market_reverts_when_maintenance_margin_greater_than_max(
     expect_k = 1220000000000
     expect_lmbda = 1000000000000000000
     expect_delta = 2500000000000000
-    expect_cap_oi = 800000000000000000000000
+    expect_cap_notional = 800000000000000000000000
     expect_cap_payoff = 5000000000000000000
     # NOTE: set cap leverage to min to avoid market setter check revert
     expect_cap_leverage = factory.MIN_CAP_LEVERAGE()
@@ -1247,7 +1247,7 @@ def test_deploy_market_reverts_when_maintenance_margin_greater_than_max(
     expect_maintenance_margin_fraction = \
         factory.MAX_MAINTENANCE_MARGIN_FRACTION() + 1
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -1267,7 +1267,7 @@ def test_deploy_market_reverts_when_maintenance_margin_greater_than_max(
     expect_maintenance_margin_fraction = \
         factory.MAX_MAINTENANCE_MARGIN_FRACTION()
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -1298,7 +1298,7 @@ def test_deploy_market_reverts_when_maintenance_margin_burn_less_than_min(
     expect_k = 1220000000000
     expect_lmbda = 1000000000000000000
     expect_delta = 2500000000000000
-    expect_cap_oi = 800000000000000000000000
+    expect_cap_notional = 800000000000000000000000
     expect_cap_payoff = 5000000000000000000
     expect_cap_leverage = 5000000000000000000
     expect_circuit_breaker_window = 2592000
@@ -1313,7 +1313,7 @@ def test_deploy_market_reverts_when_maintenance_margin_burn_less_than_min(
     expect_maintenance_margin_burn_rate = \
         factory.MIN_MAINTENANCE_MARGIN_BURN_RATE() - 1
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -1333,7 +1333,7 @@ def test_deploy_market_reverts_when_maintenance_margin_burn_less_than_min(
     expect_maintenance_margin_burn_rate = \
         factory.MIN_MAINTENANCE_MARGIN_BURN_RATE()
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -1363,7 +1363,7 @@ def test_deploy_market_reverts_when_maintenance_margin_burn_greater_than_max(
     expect_k = 1220000000000
     expect_lmbda = 1000000000000000000
     expect_delta = 2500000000000000
-    expect_cap_oi = 800000000000000000000000
+    expect_cap_notional = 800000000000000000000000
     expect_cap_payoff = 5000000000000000000
     expect_cap_leverage = 5000000000000000000
     expect_circuit_breaker_window = 2592000
@@ -1378,7 +1378,7 @@ def test_deploy_market_reverts_when_maintenance_margin_burn_greater_than_max(
     expect_maintenance_margin_burn_rate = \
         factory.MAX_MAINTENANCE_MARGIN_BURN_RATE() + 1
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -1398,7 +1398,7 @@ def test_deploy_market_reverts_when_maintenance_margin_burn_greater_than_max(
     expect_maintenance_margin_burn_rate = \
         factory.MAX_MAINTENANCE_MARGIN_BURN_RATE()
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -1429,7 +1429,7 @@ def test_deploy_market_reverts_when_liquidation_fee_rate_less_than_min(
     expect_k = 1220000000000
     expect_lmbda = 1000000000000000000
     expect_delta = 2500000000000000
-    expect_cap_oi = 800000000000000000000000
+    expect_cap_notional = 800000000000000000000000
     expect_cap_payoff = 5000000000000000000
     expect_cap_leverage = 5000000000000000000
     expect_circuit_breaker_window = 2592000
@@ -1444,7 +1444,7 @@ def test_deploy_market_reverts_when_liquidation_fee_rate_less_than_min(
     expect_liquidation_fee_rate = \
         factory.MIN_LIQUIDATION_FEE_RATE() - 1
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -1464,7 +1464,7 @@ def test_deploy_market_reverts_when_liquidation_fee_rate_less_than_min(
     expect_liquidation_fee_rate = \
         factory.MIN_LIQUIDATION_FEE_RATE()
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -1494,7 +1494,7 @@ def test_deploy_market_reverts_when_liquidation_fee_rate_greater_than_max(
     expect_k = 1220000000000
     expect_lmbda = 1000000000000000000
     expect_delta = 2500000000000000
-    expect_cap_oi = 800000000000000000000000
+    expect_cap_notional = 800000000000000000000000
     expect_cap_payoff = 5000000000000000000
     expect_cap_leverage = 5000000000000000000
     expect_circuit_breaker_window = 2592000
@@ -1509,7 +1509,7 @@ def test_deploy_market_reverts_when_liquidation_fee_rate_greater_than_max(
     expect_liquidation_fee_rate = \
         factory.MAX_LIQUIDATION_FEE_RATE() + 1
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -1529,7 +1529,7 @@ def test_deploy_market_reverts_when_liquidation_fee_rate_greater_than_max(
     expect_liquidation_fee_rate = \
         factory.MAX_LIQUIDATION_FEE_RATE()
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -1560,7 +1560,7 @@ def test_deploy_market_reverts_when_trading_fee_less_than_min(
     expect_k = 1220000000000
     expect_lmbda = 1000000000000000000
     expect_delta = 2500000000000000
-    expect_cap_oi = 800000000000000000000000
+    expect_cap_notional = 800000000000000000000000
     expect_cap_payoff = 5000000000000000000
     expect_cap_leverage = 5000000000000000000
     expect_circuit_breaker_window = 2592000
@@ -1574,7 +1574,7 @@ def test_deploy_market_reverts_when_trading_fee_less_than_min(
     # check can't deploy with tradingFeeRate less than min
     expect_trading_fee_rate = factory.MIN_TRADING_FEE_RATE() - 1
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -1593,7 +1593,7 @@ def test_deploy_market_reverts_when_trading_fee_less_than_min(
     # check deploys with tradingFeeRate equal to min
     expect_trading_fee_rate = factory.MIN_TRADING_FEE_RATE()
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -1623,7 +1623,7 @@ def test_deploy_market_reverts_when_trading_fee_greater_than_max(
     expect_k = 1220000000000
     expect_lmbda = 1000000000000000000
     expect_delta = 2500000000000000
-    expect_cap_oi = 800000000000000000000000
+    expect_cap_notional = 800000000000000000000000
     expect_cap_payoff = 5000000000000000000
     expect_cap_leverage = 5000000000000000000
     expect_circuit_breaker_window = 2592000
@@ -1637,7 +1637,7 @@ def test_deploy_market_reverts_when_trading_fee_greater_than_max(
     # check can't deploy with tradingFeeRate greater than max
     expect_trading_fee_rate = factory.MAX_TRADING_FEE_RATE() + 1
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -1656,7 +1656,7 @@ def test_deploy_market_reverts_when_trading_fee_greater_than_max(
     # check deploys with tradingFeeRate equal to max
     expect_trading_fee_rate = factory.MAX_TRADING_FEE_RATE()
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -1687,7 +1687,7 @@ def test_deploy_market_reverts_when_min_collateral_less_than_min(
     expect_k = 1220000000000
     expect_lmbda = 1000000000000000000
     expect_delta = 2500000000000000
-    expect_cap_oi = 800000000000000000000000
+    expect_cap_notional = 800000000000000000000000
     expect_cap_payoff = 5000000000000000000
     expect_cap_leverage = 5000000000000000000
     expect_circuit_breaker_window = 2592000
@@ -1701,7 +1701,7 @@ def test_deploy_market_reverts_when_min_collateral_less_than_min(
     # check can't deploy with minCollateral less than min
     expect_min_collateral = factory.MIN_MINIMUM_COLLATERAL() - 1
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -1720,7 +1720,7 @@ def test_deploy_market_reverts_when_min_collateral_less_than_min(
     # check deploys with minCollateral equal to min
     expect_min_collateral = factory.MIN_MINIMUM_COLLATERAL()
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -1750,7 +1750,7 @@ def test_deploy_market_reverts_when_min_collateral_greater_than_max(
     expect_k = 1220000000000
     expect_lmbda = 1000000000000000000
     expect_delta = 2500000000000000
-    expect_cap_oi = 800000000000000000000000
+    expect_cap_notional = 800000000000000000000000
     expect_cap_payoff = 5000000000000000000
     expect_cap_leverage = 5000000000000000000
     expect_circuit_breaker_window = 2592000
@@ -1764,7 +1764,7 @@ def test_deploy_market_reverts_when_min_collateral_greater_than_max(
     # check can't deploy with minCollateral greater than max
     expect_min_collateral = factory.MAX_MINIMUM_COLLATERAL() + 1
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -1783,7 +1783,7 @@ def test_deploy_market_reverts_when_min_collateral_greater_than_max(
     # check deploys with minCollateral equal to max
     expect_min_collateral = factory.MAX_MINIMUM_COLLATERAL()
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -1814,7 +1814,7 @@ def test_deploy_market_reverts_when_price_drift_less_than_min(
     expect_k = 1220000000000
     expect_lmbda = 1000000000000000000
     expect_delta = 2500000000000000
-    expect_cap_oi = 800000000000000000000000
+    expect_cap_notional = 800000000000000000000000
     expect_cap_payoff = 5000000000000000000
     expect_cap_leverage = 5000000000000000000
     expect_circuit_breaker_window = 2592000
@@ -1828,7 +1828,7 @@ def test_deploy_market_reverts_when_price_drift_less_than_min(
     # check can't deploy with priceDriftUpperLimit less than min
     expect_price_drift_upper_limit = factory.MIN_PRICE_DRIFT_UPPER_LIMIT() - 1
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -1847,7 +1847,7 @@ def test_deploy_market_reverts_when_price_drift_less_than_min(
     # check deploys with priceDriftUpperLimit equal to min
     expect_price_drift_upper_limit = factory.MIN_PRICE_DRIFT_UPPER_LIMIT()
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -1877,7 +1877,7 @@ def test_deploy_market_reverts_when_price_drift_greater_than_max(
     expect_k = 1220000000000
     expect_lmbda = 1000000000000000000
     expect_delta = 2500000000000000
-    expect_cap_oi = 800000000000000000000000
+    expect_cap_notional = 800000000000000000000000
     expect_cap_payoff = 5000000000000000000
     expect_cap_leverage = 5000000000000000000
     expect_circuit_breaker_window = 2592000
@@ -1891,7 +1891,7 @@ def test_deploy_market_reverts_when_price_drift_greater_than_max(
     # check can't deploy with priceDriftUpperLimit greater than max
     expect_price_drift_upper_limit = factory.MAX_PRICE_DRIFT_UPPER_LIMIT() + 1
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,
@@ -1910,7 +1910,7 @@ def test_deploy_market_reverts_when_price_drift_greater_than_max(
     # check deploys with priceDriftUpperLimit equal to max
     expect_price_drift_upper_limit = factory.MAX_PRICE_DRIFT_UPPER_LIMIT()
     expect_params = (expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
-                     expect_cap_oi, expect_cap_leverage,
+                     expect_cap_notional, expect_cap_leverage,
                      expect_circuit_breaker_window,
                      expect_circuit_breaker_mint_target,
                      expect_maintenance_margin_fraction,

--- a/tests/factories/market/test_setters.py
+++ b/tests/factories/market/test_setters.py
@@ -303,56 +303,56 @@ def test_set_cap_payoff_reverts_when_greater_than_max(factory, market, gov):
     assert actual_cap_payoff == expect_cap_payoff
 
 
-# capOi tests
-def test_set_cap_oi(factory, market, gov):
+# capNotional tests
+def test_set_cap_notional(factory, market, gov):
     feed = market.feed()
-    expect_cap_oi = 700000000000000000000
+    expect_cap_notional = 700000000000000000000
 
-    # set capOi
-    tx = factory.setCapOi(feed, expect_cap_oi, {"from": gov})
+    # set capNotional
+    tx = factory.setCapNotional(feed, expect_cap_notional, {"from": gov})
 
-    # check capOi changed
-    actual_cap_oi = market.capOi()
-    assert expect_cap_oi == actual_cap_oi
+    # check capNotional changed
+    actual_cap_notional = market.capNotional()
+    assert expect_cap_notional == actual_cap_notional
 
     # check event emitted
-    assert 'OpenInterestCapUpdated' in tx.events
+    assert 'NotionalCapUpdated' in tx.events
     expect_event = OrderedDict({
         "user": gov,
         "market": market,
-        "capOi": expect_cap_oi
+        "capNotional": expect_cap_notional
     })
-    actual_event = tx.events['OpenInterestCapUpdated']
+    actual_event = tx.events['NotionalCapUpdated']
     assert actual_event == expect_event
 
 
-def test_set_cap_oi_reverts_when_not_gov(factory, market, alice):
+def test_set_cap_notional_reverts_when_not_gov(factory, market, alice):
     feed = market.feed()
-    expect_cap_oi = 700000000000000000000
+    expect_cap_notional = 700000000000000000000
 
-    # check can't set capOi with non gov account
+    # check can't set capNotional with non gov account
     with reverts("OVLV1: !governor"):
-        _ = factory.setCapOi(feed, expect_cap_oi, {"from": alice})
+        _ = factory.setCapNotional(feed, expect_cap_notional, {"from": alice})
 
 
-# NOTE: don't have test_set_cap_oi_reverts_when_less_than_min because
-# MIN_CAP_OI is zero
+# NOTE: don't have test_set_cap_notional_reverts_when_less_than_min because
+# MIN_CAP_NOTIONAL is zero
 
 
-def test_set_cap_oi_reverts_when_greater_than_max(factory, market, gov):
+def test_set_cap_notional_reverts_when_greater_than_max(factory, market, gov):
     feed = market.feed()
-    expect_cap_oi = factory.MAX_CAP_OI() + 1
+    expect_cap_notional = factory.MAX_CAP_NOTIONAL() + 1
 
-    # check can't set capOi greater than max
-    with reverts("OVLV1: capOi out of bounds"):
-        _ = factory.setCapOi(feed, expect_cap_oi, {"from": gov})
+    # check can't set capNotional greater than max
+    with reverts("OVLV1: capNotional out of bounds"):
+        _ = factory.setCapNotional(feed, expect_cap_notional, {"from": gov})
 
-    # check can set capOi when equal to max
-    expect_cap_oi = factory.MAX_CAP_OI()
-    factory.setCapOi(feed, expect_cap_oi, {"from": gov})
+    # check can set capNotional when equal to max
+    expect_cap_notional = factory.MAX_CAP_NOTIONAL()
+    factory.setCapNotional(feed, expect_cap_notional, {"from": gov})
 
-    actual_cap_oi = market.capOi()
-    assert actual_cap_oi == expect_cap_oi
+    actual_cap_notional = market.capNotional()
+    assert actual_cap_notional == expect_cap_notional
 
 
 # capLeverage tests

--- a/tests/factories/market/test_setters.py
+++ b/tests/factories/market/test_setters.py
@@ -932,7 +932,7 @@ def test_set_min_collateral_reverts_when_greater_than_max(factory, market,
 # priceDriftUpperLimit tests
 def test_set_price_drift_upper_limit(factory, market, gov):
     feed = market.feed()
-    expect_price_drift_upper_limit = 700000000000000
+    expect_price_drift_upper_limit = 70000000000000
 
     # set priceDriftUpperLimit
     tx = factory.setPriceDriftUpperLimit(feed, expect_price_drift_upper_limit,

--- a/tests/libraries/fixedpoint/test_pow.py
+++ b/tests/libraries/fixedpoint/test_pow.py
@@ -1,6 +1,26 @@
+from pytest import approx
+
+
+def test_pow_up(fixed_point):
+    # test for x**2 and x**(1/2)
+    x = 500000000000000000  # 0.5
+
+    # check pow returns 1/4 when base is 1/2 and exponent is 2
+    y = 2000000000000000000  # 2
+    expect = 250000000000000000  # 0.25
+    actual = fixed_point.powUp(x, y)
+    assert expect == approx(actual)
+
+    # check pow returns 1/sqrt(2) when base is 1/2 and exponent is 1/2
+    y = 500000000000000000  # 0.5
+    expect = 707106781186547456  # 0.707106781186547456
+    actual = fixed_point.powUp(x, y)
+    assert expect == approx(actual)
+
+
 def test_pow_up_when_base_is_zero_and_power_is_nonzero(fixed_point):
     x = 0  # base is zero
-    y = 10  # power is nonzero
+    y = int(10 * 1e18)  # power is nonzero
 
     # check pow returns 0 when base is zero and exponent is nonzero
     expect = 0
@@ -21,7 +41,7 @@ def test_pow_up_when_base_is_zero_and_power_is_zero(fixed_point):
 
 def test_pow_up_when_base_is_one_and_power_is_nonzero(fixed_point):
     x = int(1e18)  # base is ONE
-    y = 10  # power is zero
+    y = int(10 * 1e18)  # power is nonzero
 
     # check pow returns 1 when base is one and exponent is nonzero
     expect = int(1e18)
@@ -39,9 +59,27 @@ def test_pow_up_when_base_is_one_and_power_is_zero(fixed_point):
     assert expect == actual
 
 
+def test_pow_down(fixed_point):
+    # test for x**2 and x**(1/2)
+    x = 500000000000000000  # 0.5
+
+    # check pow returns 1/4 when base is 1/2 and exponent is 2
+    y = 2000000000000000000  # 2
+    expect = 250000000000000000  # 0.25
+    actual = fixed_point.powDown(x, y)
+
+    assert expect == approx(actual)
+
+    # check pow returns 1/sqrt(2) when base is 1/2 and exponent is 1/2
+    y = 500000000000000000  # 0.5
+    expect = 707106781186547456  # 0.707106781186547456
+    actual = fixed_point.powDown(x, y)
+    assert expect == approx(actual)
+
+
 def test_pow_down_when_base_is_zero_and_power_is_nonzero(fixed_point):
     x = 0  # base is zero
-    y = 10  # power is nonzero
+    y = int(10 * 1e18)  # power is nonzero
 
     # check pow returns 0 when base is zero and exponent is nonzero
     expect = 0
@@ -62,7 +100,7 @@ def test_pow_down_when_base_is_zero_and_power_is_zero(fixed_point):
 
 def test_pow_down_when_base_is_one_and_power_is_nonzero(fixed_point):
     x = int(1e18)  # base is ONE
-    y = 10  # power is zero
+    y = int(10 * 1e18)  # power is zero
 
     # check pow returns 1 when base is one and exponent is nonzero
     expect = int(1e18)

--- a/tests/libraries/position/test_fee.py
+++ b/tests/libraries/position/test_fee.py
@@ -13,7 +13,7 @@ def test_trading_fee(position):
     # check trading fee is notional * fee_rate
     is_long = True
     expect = 11250000000000000
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.tradingFee(pos, fraction, oi, oi, current_price,
                                  cap_payoff, trading_fee_rate)
     assert expect == actual
@@ -21,7 +21,7 @@ def test_trading_fee(position):
     # check trading fee is notional * fee_rate
     is_long = False
     expect = 3750000000000000
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.tradingFee(pos, fraction, oi, oi, current_price,
                                  cap_payoff, trading_fee_rate)
     assert expect == actual
@@ -30,7 +30,7 @@ def test_trading_fee(position):
     is_long = True
     current_price = entry_price
     expect = 7500000000000000
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.tradingFee(pos, fraction, oi, oi, current_price,
                                  cap_payoff, trading_fee_rate)
     assert expect == actual
@@ -39,7 +39,7 @@ def test_trading_fee(position):
     is_long = False
     current_price = entry_price
     expect = 7500000000000000
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.tradingFee(pos, fraction, oi, oi, current_price,
                                  cap_payoff, trading_fee_rate)
     assert expect == actual
@@ -60,7 +60,7 @@ def test_trading_fee_when_fraction_less_than_one(position):
     # check trading fee is notional * fee_rate
     is_long = True
     expect = 2812500000000000
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.tradingFee(pos, fraction, oi, oi, current_price,
                                  cap_payoff, trading_fee_rate)
     assert expect == actual
@@ -68,7 +68,7 @@ def test_trading_fee_when_fraction_less_than_one(position):
     # check trading fee is notional * fee_rate
     is_long = False
     expect = 937500000000000
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.tradingFee(pos, fraction, oi, oi, current_price,
                                  cap_payoff, trading_fee_rate)
     assert expect == actual
@@ -89,7 +89,7 @@ def test_trading_fee_when_payoff_greater_than_cap(position):
     # check trading fee is notional * fee_rate
     is_long = True
     expect = 45000000000000000
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.tradingFee(pos, fraction, oi, oi, current_price,
                                  cap_payoff, trading_fee_rate)
     assert expect == actual

--- a/tests/libraries/position/test_fee.py
+++ b/tests/libraries/position/test_fee.py
@@ -1,18 +1,19 @@
 def test_trading_fee(position):
     entry_price = 100000000000000000000  # 100
     current_price = 150000000000000000000  # 150
-    oi = 10000000000000000000  # 10
+    notional = 10000000000000000000  # 10
     debt = 2000000000000000000  # 2
     liquidated = False
     trading_fee_rate = 750000000000000
 
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
     fraction = 1000000000000000000  # 1
     cap_payoff = 5000000000000000000  # 5
 
     # check trading fee is notional * fee_rate
     is_long = True
     expect = 11250000000000000
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.tradingFee(pos, fraction, oi, oi, current_price,
                                  cap_payoff, trading_fee_rate)
     assert expect == actual
@@ -20,25 +21,25 @@ def test_trading_fee(position):
     # check trading fee is notional * fee_rate
     is_long = False
     expect = 3750000000000000
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.tradingFee(pos, fraction, oi, oi, current_price,
                                  cap_payoff, trading_fee_rate)
     assert expect == actual
 
-    # check trading fee is oi * fee_rate when 0 price change
+    # check trading fee is notional * fee_rate when 0 price change
     is_long = True
     current_price = entry_price
     expect = 7500000000000000
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.tradingFee(pos, fraction, oi, oi, current_price,
                                  cap_payoff, trading_fee_rate)
     assert expect == actual
 
-    # check trading fee is oi * fee_rate when 0 price change
+    # check trading fee is notional * fee_rate when 0 price change
     is_long = False
     current_price = entry_price
     expect = 7500000000000000
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.tradingFee(pos, fraction, oi, oi, current_price,
                                  cap_payoff, trading_fee_rate)
     assert expect == actual
@@ -47,18 +48,19 @@ def test_trading_fee(position):
 def test_trading_fee_when_fraction_less_than_one(position):
     entry_price = 100000000000000000000  # 100
     current_price = 150000000000000000000  # 150
-    oi = 10000000000000000000  # 10
+    notional = 10000000000000000000  # 10
     debt = 2000000000000000000  # 2
     liquidated = False
     trading_fee_rate = 750000000000000
 
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
     fraction = 250000000000000000  # 0.25
     cap_payoff = 5000000000000000000  # 5
 
     # check trading fee is notional * fee_rate
     is_long = True
     expect = 2812500000000000
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.tradingFee(pos, fraction, oi, oi, current_price,
                                  cap_payoff, trading_fee_rate)
     assert expect == actual
@@ -66,7 +68,7 @@ def test_trading_fee_when_fraction_less_than_one(position):
     # check trading fee is notional * fee_rate
     is_long = False
     expect = 937500000000000
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.tradingFee(pos, fraction, oi, oi, current_price,
                                  cap_payoff, trading_fee_rate)
     assert expect == actual
@@ -75,18 +77,19 @@ def test_trading_fee_when_fraction_less_than_one(position):
 def test_trading_fee_when_payoff_greater_than_cap(position):
     entry_price = 100000000000000000000  # 100
     current_price = 800000000000000000000  # 800
-    oi = 10000000000000000000  # 10
+    notional = 10000000000000000000  # 10
     debt = 2000000000000000000  # 2
     liquidated = False
     trading_fee_rate = 750000000000000
 
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
     fraction = 1000000000000000000  # 1
     cap_payoff = 5000000000000000000  # 5
 
     # check trading fee is notional * fee_rate
     is_long = True
     expect = 45000000000000000
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.tradingFee(pos, fraction, oi, oi, current_price,
                                  cap_payoff, trading_fee_rate)
     assert expect == actual

--- a/tests/libraries/position/test_getters.py
+++ b/tests/libraries/position/test_getters.py
@@ -1,35 +1,39 @@
 def test_oi_shares_current(position):
-    oi = 10000000000000000000  # 10
+    notional = 10000000000000000000  # 10
     debt = 2000000000000000000  # 2
     is_long = True
     liquidated = False
     entry_price = 100000000000000000000  # 100
     fraction = 1000000000000000000  # 1
 
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
+
     # check oiShares * fraction
     expect = int(oi * (fraction / 1e18))  # 10
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.oiSharesCurrent(pos, fraction)
     assert expect == actual
 
 
 def test_oi_shares_current_when_fraction_less_than_one(position):
-    oi = 10000000000000000000  # 10
+    notional = 10000000000000000000  # 10
     debt = 2000000000000000000  # 2
     is_long = True
     liquidated = False
     entry_price = 100000000000000000000  # 100
     fraction = 250000000000000000  # 0.25
 
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
+
     # check oiShares * fraction
     expect = int(oi * (fraction / 1e18))  # 10
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.oiSharesCurrent(pos, fraction)
     assert expect == actual
 
 
 def test_debt_current(position):
-    oi = 10000000000000000000  # 10
+    notional = 10000000000000000000  # 10
     debt = 2000000000000000000  # 2
     is_long = True
     liquidated = False
@@ -38,13 +42,13 @@ def test_debt_current(position):
 
     # check oiShares * fraction
     expect = int(debt * (fraction / 1e18))  # 2
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.debtCurrent(pos, fraction)
     assert expect == actual
 
 
 def test_debt_current_when_fraction_less_than_one(position):
-    oi = 10000000000000000000  # 10
+    notional = 10000000000000000000  # 10
     debt = 2000000000000000000  # 2
     is_long = True
     liquidated = False
@@ -53,58 +57,62 @@ def test_debt_current_when_fraction_less_than_one(position):
 
     # check oiShares * fraction
     expect = int(debt * (fraction / 1e18))  # 2
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.debtCurrent(pos, fraction)
     assert expect == actual
 
 
 def test_oi_initial(position):
-    oi = 10000000000000000000  # 10
+    notional = 10000000000000000000  # 10
     debt = 2000000000000000000  # 2
     is_long = True
     liquidated = False
     entry_price = 100000000000000000000  # 100
     fraction = 1000000000000000000  # 1
 
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
+
     # check oiShares * fraction
     expect = int(oi * (fraction / 1e18))  # 2
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.oiInitial(pos, fraction)
     assert expect == actual
 
 
 def test_oi_initial_when_fraction_less_than_one(position):
-    oi = 10000000000000000000  # 10
+    notional = 10000000000000000000  # 10
     debt = 2000000000000000000  # 2
     is_long = True
     liquidated = False
     entry_price = 100000000000000000000  # 100
     fraction = 250000000000000000  # 0.25
 
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
+
     # check oiShares * fraction
     expect = int(oi * (fraction / 1e18))  # 2
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.oiInitial(pos, fraction)
     assert expect == actual
 
 
 def test_cost(position):
-    oi = 10000000000000000000  # 10
+    notional = 10000000000000000000  # 10
     debt = 2000000000000000000  # 2
     is_long = True
     liquidated = False
     entry_price = 100000000000000000000  # 100
     fraction = 1000000000000000000  # 1
 
-    # check cost = oi - debt
-    expect = int((oi - debt) * (fraction / 1e18))  # 8
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    # check cost = notional - debt
+    expect = int((notional - debt) * (fraction / 1e18))  # 8
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.cost(pos, fraction)
     assert expect == actual
 
 
 def test_cost_when_fraction_less_than_one(position):
-    oi = 10000000000000000000  # 10
+    notional = 10000000000000000000  # 10
     debt = 2000000000000000000  # 2
     is_long = True
     liquidated = False
@@ -112,14 +120,14 @@ def test_cost_when_fraction_less_than_one(position):
     fraction = 250000000000000000  # 0.25
 
     # check cost = oi - debt
-    expect = int((oi - debt) * (fraction / 1e18))  # 8
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    expect = int((notional - debt) * (fraction / 1e18))  # 8
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.cost(pos, fraction)
     assert expect == actual
 
 
 def test_exists(position):
-    oi = 10000000000000000000  # 10
+    notional = 10000000000000000000  # 10
     debt = 2000000000000000000  # 2
     is_long = True
     liquidated = False
@@ -127,13 +135,13 @@ def test_exists(position):
 
     # check exists when not liquidated and oi > 0
     expect = True
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.exists(pos)
     assert expect == actual
 
 
 def test_exists_when_liquidated(position):
-    oi = 10000000000000000000  # 10
+    notional = 10000000000000000000  # 10
     debt = 2000000000000000000  # 2
     is_long = True
     liquidated = True
@@ -141,13 +149,13 @@ def test_exists_when_liquidated(position):
 
     # check exists when not liquidated and oi > 0
     expect = False
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.exists(pos)
     assert expect == actual
 
 
 def test_exists_when_oi_zero(position):
-    oi = 0  # 0
+    notional = 0  # 0
     debt = 2000000000000000000  # 2
     is_long = True
     liquidated = False
@@ -155,6 +163,6 @@ def test_exists_when_oi_zero(position):
 
     # check exists when not liquidated and oi > 0
     expect = False
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.exists(pos)
     assert expect == actual

--- a/tests/libraries/position/test_getters.py
+++ b/tests/libraries/position/test_getters.py
@@ -10,7 +10,7 @@ def test_oi_shares_current(position):
 
     # check oiShares * fraction
     expect = int(oi * (fraction / 1e18))  # 10
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.oiSharesCurrent(pos, fraction)
     assert expect == actual
 
@@ -27,12 +27,12 @@ def test_oi_shares_current_when_fraction_less_than_one(position):
 
     # check oiShares * fraction
     expect = int(oi * (fraction / 1e18))  # 10
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.oiSharesCurrent(pos, fraction)
     assert expect == actual
 
 
-def test_debt_current(position):
+def test_debt(position):
     notional = 10000000000000000000  # 10
     debt = 2000000000000000000  # 2
     is_long = True
@@ -40,14 +40,16 @@ def test_debt_current(position):
     entry_price = 100000000000000000000  # 100
     fraction = 1000000000000000000  # 1
 
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
+
     # check oiShares * fraction
     expect = int(debt * (fraction / 1e18))  # 2
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.debtCurrent(pos, fraction)
     assert expect == actual
 
 
-def test_debt_current_when_fraction_less_than_one(position):
+def test_debt_when_fraction_less_than_one(position):
     notional = 10000000000000000000  # 10
     debt = 2000000000000000000  # 2
     is_long = True
@@ -55,9 +57,11 @@ def test_debt_current_when_fraction_less_than_one(position):
     entry_price = 100000000000000000000  # 100
     fraction = 250000000000000000  # 0.25
 
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
+
     # check oiShares * fraction
     expect = int(debt * (fraction / 1e18))  # 2
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.debtCurrent(pos, fraction)
     assert expect == actual
 
@@ -74,7 +78,7 @@ def test_oi_initial(position):
 
     # check oiShares * fraction
     expect = int(oi * (fraction / 1e18))  # 2
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.oiInitial(pos, fraction)
     assert expect == actual
 
@@ -91,7 +95,7 @@ def test_oi_initial_when_fraction_less_than_one(position):
 
     # check oiShares * fraction
     expect = int(oi * (fraction / 1e18))  # 2
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.oiInitial(pos, fraction)
     assert expect == actual
 
@@ -104,9 +108,11 @@ def test_cost(position):
     entry_price = 100000000000000000000  # 100
     fraction = 1000000000000000000  # 1
 
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
+
     # check cost = notional - debt
     expect = int((notional - debt) * (fraction / 1e18))  # 8
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.cost(pos, fraction)
     assert expect == actual
 
@@ -119,9 +125,11 @@ def test_cost_when_fraction_less_than_one(position):
     entry_price = 100000000000000000000  # 100
     fraction = 250000000000000000  # 0.25
 
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
+
     # check cost = oi - debt
     expect = int((notional - debt) * (fraction / 1e18))  # 8
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.cost(pos, fraction)
     assert expect == actual
 
@@ -133,9 +141,11 @@ def test_exists(position):
     liquidated = False
     entry_price = 100000000000000000000  # 100
 
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
+
     # check exists when not liquidated and oi > 0
     expect = True
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.exists(pos)
     assert expect == actual
 
@@ -147,9 +157,11 @@ def test_exists_when_liquidated(position):
     liquidated = True
     entry_price = 100000000000000000000  # 100
 
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
+
     # check exists when not liquidated and oi > 0
     expect = False
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.exists(pos)
     assert expect == actual
 
@@ -161,8 +173,10 @@ def test_exists_when_oi_zero(position):
     liquidated = False
     entry_price = 100000000000000000000  # 100
 
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
+
     # check exists when not liquidated and oi > 0
     expect = False
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.exists(pos)
     assert expect == actual

--- a/tests/libraries/position/test_liquidation.py
+++ b/tests/libraries/position/test_liquidation.py
@@ -15,7 +15,7 @@ def test_liquidatable(position):
     is_long = True
     current_price = 90000000000000000000 * (1 - tol)  # 90 * (1-tol)
     expect = True
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.liquidatable(pos, oi, oi, current_price, cap_payoff,
                                    maintenance)
     assert expect == actual
@@ -24,7 +24,7 @@ def test_liquidatable(position):
     is_long = True
     current_price = 90000000000000000000 * (1 + tol)  # 90 * (1+tol)
     expect = False
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.liquidatable(pos, oi, oi, current_price, cap_payoff,
                                    maintenance)
     assert expect == actual
@@ -33,7 +33,7 @@ def test_liquidatable(position):
     is_long = False
     current_price = 110000000000000000000 * (1 + tol)  # 110 * (1+tol)
     expect = True
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.liquidatable(pos, oi, oi, current_price, cap_payoff,
                                    maintenance)
     assert expect == actual
@@ -42,7 +42,7 @@ def test_liquidatable(position):
     is_long = False
     current_price = 110000000000000000000 * (1 - tol)  # 110 * (1-tol)
     expect = False
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.liquidatable(pos, oi, oi, current_price, cap_payoff,
                                    maintenance)
     assert expect == actual
@@ -62,7 +62,7 @@ def test_liquidatable_when_oi_zero(position):
     # check returns False when long oi is zero
     is_long = True
     expect = False
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.liquidatable(pos, oi, oi, current_price, cap_payoff,
                                    maintenance)
     assert expect == actual
@@ -70,7 +70,7 @@ def test_liquidatable_when_oi_zero(position):
     # check returns False when short oi is zero
     is_long = False
     expect = False
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.liquidatable(pos, oi, oi, current_price, cap_payoff,
                                    maintenance)
     assert expect == actual
@@ -90,7 +90,7 @@ def test_liquidatable_when_liquidated(position):
     # check returns False when long oi is zero
     is_long = True
     expect = False
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.liquidatable(pos, oi, oi, current_price, cap_payoff,
                                    maintenance)
     assert expect == actual
@@ -98,7 +98,7 @@ def test_liquidatable_when_liquidated(position):
     # check returns False when short oi is zero
     is_long = False
     expect = False
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.liquidatable(pos, oi, oi, current_price, cap_payoff,
                                    maintenance)
     assert expect == actual
@@ -120,7 +120,7 @@ def test_liquidatable_when_leverage_one(position):
     is_long = True
     current_price = 10000000000000000000 * (1 + tol)  # 10 * (1+tol)
     expect = False
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.liquidatable(pos, oi, oi, current_price, cap_payoff,
                                    maintenance)
     assert expect == actual
@@ -129,7 +129,7 @@ def test_liquidatable_when_leverage_one(position):
     is_long = True
     current_price = 10000000000000000000 * (1 - tol)  # 10 * (1-tol)
     expect = True
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.liquidatable(pos, oi, oi, current_price, cap_payoff,
                                    maintenance)
     assert expect == actual
@@ -138,7 +138,7 @@ def test_liquidatable_when_leverage_one(position):
     is_long = False
     current_price = 190000000000000000000 * (1 - tol)  # 190 * (1-tol)
     expect = False
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.liquidatable(pos, oi, oi, current_price, cap_payoff,
                                    maintenance)
     assert expect == actual
@@ -147,7 +147,7 @@ def test_liquidatable_when_leverage_one(position):
     is_long = False
     current_price = 190000000000000000000 * (1 + tol)  # 190 * (1+tol)
     expect = True
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.liquidatable(pos, oi, oi, current_price, cap_payoff,
                                    maintenance)
     assert expect == actual
@@ -166,14 +166,14 @@ def test_liquidation_price(position):
     # check returns correct liquidation price for long
     is_long = True
     expect = 90000000000000000000
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.liquidationPrice(pos, oi, oi, maintenance)
     assert expect == actual
 
     # check returns correct liquidation price for short
     is_long = False
     expect = 110000000000000000000
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.liquidationPrice(pos, oi, oi, maintenance)
     assert expect == actual
 
@@ -188,7 +188,8 @@ def test_liquidation_price_when_oi_zero(position):
     # check liqPrice is zero when posOiInitial is zero
     notional = 0
     total_oi = 100
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
 
     expect = 0
     actual = position.liquidationPrice(pos, total_oi, total_oi, maintenance)
@@ -197,7 +198,8 @@ def test_liquidation_price_when_oi_zero(position):
     # check liqPrice is zero when posOiCurrent is zero
     notional = 100
     total_oi = 0
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
 
     expect = 0
     actual = position.liquidationPrice(pos, total_oi, total_oi, maintenance)
@@ -214,7 +216,8 @@ def test_liquidation_price_when_liquidated_is_true(position):
     # check liqPrice is zero when posOiInitial is zero
     notional = 100
     total_oi = 100
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
 
     expect = 0
     actual = position.liquidationPrice(pos, total_oi, total_oi, maintenance)

--- a/tests/libraries/position/test_liquidation.py
+++ b/tests/libraries/position/test_liquidation.py
@@ -1,19 +1,21 @@
 def test_liquidatable(position):
     entry_price = 100000000000000000000  # 100
-    oi = 10000000000000000000  # 10
+    notional = 10000000000000000000  # 10
     debt = 8000000000000000000  # 8
     maintenance = 100000000000000000  # 10%
     liquidated = False
     cap_payoff = 5000000000000000000  # 5
 
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
+
     tol = 1e-4  # 1 bps
 
-    # liquidatable when position.value < maintenance * initial_oi
+    # liquidatable when position.value < maintenance * initial_notional
     # check returns True when long is liquidatable
     is_long = True
     current_price = 90000000000000000000 * (1 - tol)  # 90 * (1-tol)
     expect = True
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.liquidatable(pos, oi, oi, current_price, cap_payoff,
                                    maintenance)
     assert expect == actual
@@ -22,7 +24,7 @@ def test_liquidatable(position):
     is_long = True
     current_price = 90000000000000000000 * (1 + tol)  # 90 * (1+tol)
     expect = False
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.liquidatable(pos, oi, oi, current_price, cap_payoff,
                                    maintenance)
     assert expect == actual
@@ -31,7 +33,7 @@ def test_liquidatable(position):
     is_long = False
     current_price = 110000000000000000000 * (1 + tol)  # 110 * (1+tol)
     expect = True
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.liquidatable(pos, oi, oi, current_price, cap_payoff,
                                    maintenance)
     assert expect == actual
@@ -40,7 +42,7 @@ def test_liquidatable(position):
     is_long = False
     current_price = 110000000000000000000 * (1 - tol)  # 110 * (1-tol)
     expect = False
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.liquidatable(pos, oi, oi, current_price, cap_payoff,
                                    maintenance)
     assert expect == actual
@@ -49,16 +51,18 @@ def test_liquidatable(position):
 def test_liquidatable_when_oi_zero(position):
     entry_price = 100000000000000000000  # 100
     current_price = 90000000000000000000  # 90
-    oi = 0  # 0
+    notional = 0  # 0
     debt = 8000000000000000000  # 8
     maintenance = 100000000000000000  # 10%
     liquidated = False
     cap_payoff = 5000000000000000000  # 5
 
+    oi = (notional / entry_price) * 1000000000000000000  # 0
+
     # check returns False when long oi is zero
     is_long = True
     expect = False
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.liquidatable(pos, oi, oi, current_price, cap_payoff,
                                    maintenance)
     assert expect == actual
@@ -66,7 +70,7 @@ def test_liquidatable_when_oi_zero(position):
     # check returns False when short oi is zero
     is_long = False
     expect = False
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.liquidatable(pos, oi, oi, current_price, cap_payoff,
                                    maintenance)
     assert expect == actual
@@ -75,16 +79,18 @@ def test_liquidatable_when_oi_zero(position):
 def test_liquidatable_when_liquidated(position):
     entry_price = 100000000000000000000  # 100
     current_price = 90000000000000000000  # 90
-    oi = 0  # 0
+    notional = 0  # 0
     debt = 8000000000000000000  # 8
     maintenance = 100000000000000000  # 10%
     liquidated = True
     cap_payoff = 5000000000000000000  # 5
 
+    oi = (notional / entry_price) * 1000000000000000000  # 0
+
     # check returns False when long oi is zero
     is_long = True
     expect = False
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.liquidatable(pos, oi, oi, current_price, cap_payoff,
                                    maintenance)
     assert expect == actual
@@ -92,7 +98,7 @@ def test_liquidatable_when_liquidated(position):
     # check returns False when short oi is zero
     is_long = False
     expect = False
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.liquidatable(pos, oi, oi, current_price, cap_payoff,
                                    maintenance)
     assert expect == actual
@@ -100,11 +106,13 @@ def test_liquidatable_when_liquidated(position):
 
 def test_liquidatable_when_leverage_one(position):
     entry_price = 100000000000000000000  # 100
-    oi = 10000000000000000000  # 10
+    notional = 10000000000000000000  # 10
     debt = 0  # 0
     maintenance = 100000000000000000  # 10%
     liquidated = False
     cap_payoff = 5000000000000000000  # 5
+
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
 
     tol = 1e-4  # 1bps
 
@@ -112,7 +120,7 @@ def test_liquidatable_when_leverage_one(position):
     is_long = True
     current_price = 10000000000000000000 * (1 + tol)  # 10 * (1+tol)
     expect = False
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.liquidatable(pos, oi, oi, current_price, cap_payoff,
                                    maintenance)
     assert expect == actual
@@ -121,7 +129,7 @@ def test_liquidatable_when_leverage_one(position):
     is_long = True
     current_price = 10000000000000000000 * (1 - tol)  # 10 * (1-tol)
     expect = True
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.liquidatable(pos, oi, oi, current_price, cap_payoff,
                                    maintenance)
     assert expect == actual
@@ -130,7 +138,7 @@ def test_liquidatable_when_leverage_one(position):
     is_long = False
     current_price = 190000000000000000000 * (1 - tol)  # 190 * (1-tol)
     expect = False
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.liquidatable(pos, oi, oi, current_price, cap_payoff,
                                    maintenance)
     assert expect == actual
@@ -139,7 +147,7 @@ def test_liquidatable_when_leverage_one(position):
     is_long = False
     current_price = 190000000000000000000 * (1 + tol)  # 190 * (1+tol)
     expect = True
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.liquidatable(pos, oi, oi, current_price, cap_payoff,
                                    maintenance)
     assert expect == actual
@@ -147,23 +155,25 @@ def test_liquidatable_when_leverage_one(position):
 
 def test_liquidation_price(position):
     entry_price = 100000000000000000000  # 100
-    oi = 10000000000000000000  # 10
+    notional = 10000000000000000000  # 10
     debt = 8000000000000000000  # 8
     maintenance = 100000000000000000  # 10%
     liquidated = False
+
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
 
     # liquidatable price occurs when position.value = maintenance * initial_oi
     # check returns correct liquidation price for long
     is_long = True
     expect = 90000000000000000000
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.liquidationPrice(pos, oi, oi, maintenance)
     assert expect == actual
 
     # check returns correct liquidation price for short
     is_long = False
     expect = 110000000000000000000
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.liquidationPrice(pos, oi, oi, maintenance)
     assert expect == actual
 
@@ -176,18 +186,18 @@ def test_liquidation_price_when_oi_zero(position):
     is_long = True
 
     # check liqPrice is zero when posOiInitial is zero
-    oi = 0
+    notional = 0
     total_oi = 100
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
 
     expect = 0
     actual = position.liquidationPrice(pos, total_oi, total_oi, maintenance)
     assert expect == actual
 
     # check liqPrice is zero when posOiCurrent is zero
-    oi = 100
+    notional = 100
     total_oi = 0
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
 
     expect = 0
     actual = position.liquidationPrice(pos, total_oi, total_oi, maintenance)
@@ -202,9 +212,9 @@ def test_liquidation_price_when_liquidated_is_true(position):
     is_long = True
 
     # check liqPrice is zero when posOiInitial is zero
-    oi = 100
+    notional = 100
     total_oi = 100
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
 
     expect = 0
     actual = position.liquidationPrice(pos, total_oi, total_oi, maintenance)

--- a/tests/libraries/position/test_notional.py
+++ b/tests/libraries/position/test_notional.py
@@ -4,13 +4,14 @@ def test_notional_initial(position):
     debt = 2000000000000000000  # 2
     liquidated = False
 
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
     fraction = 1000000000000000000  # 1
 
     # check initial notional is oi * entry_price = notional
     # when long
     is_long = True
     expect = notional
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.notionalInitial(pos, fraction)
     assert expect == actual
 
@@ -18,7 +19,7 @@ def test_notional_initial(position):
     # when short
     is_long = False
     expect = notional
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.notionalInitial(pos, fraction)
     assert expect == actual
 
@@ -29,13 +30,14 @@ def test_notional_initial_when_fraction_less_than_one(position):
     debt = 2000000000000000000  # 2
     liquidated = False
 
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
     fraction = 250000000000000000  # 0.25
 
     # check initial notional is oi * entry_price = notional
     # when long
     is_long = True
     expect = 2500000000000000000
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.notionalInitial(pos, fraction)
     assert expect == actual
 
@@ -43,12 +45,12 @@ def test_notional_initial_when_fraction_less_than_one(position):
     # when short
     is_long = False
     expect = 2500000000000000000
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.notionalInitial(pos, fraction)
     assert expect == actual
 
 
-def test_notional_current(position):
+def test_notional_with_pnl(position):
     entry_price = 100000000000000000000  # 100
     current_price = 150000000000000000000  # 150
     notional = 10000000000000000000  # 10
@@ -63,8 +65,8 @@ def test_notional_current(position):
     # when long
     is_long = True
     expect = 15000000000000000000
-    pos = (notional, debt, is_long, liquidated, entry_price)
-    actual = position.notionalCurrent(pos, fraction, oi, oi, current_price,
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
+    actual = position.notionalWithPnl(pos, fraction, oi, oi, current_price,
                                       cap_payoff)
     assert expect == actual
 
@@ -72,13 +74,13 @@ def test_notional_current(position):
     # when short
     is_long = False
     expect = 5000000000000000000
-    pos = (notional, debt, is_long, liquidated, entry_price)
-    actual = position.notionalCurrent(pos, fraction, oi, oi, current_price,
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
+    actual = position.notionalWithPnl(pos, fraction, oi, oi, current_price,
                                       cap_payoff)
     assert expect == actual
 
 
-def test_notional_current_when_fraction_less_than_one(position):
+def test_notional_with_pnl_when_fraction_less_than_one(position):
     entry_price = 100000000000000000000  # 100
     current_price = 150000000000000000000  # 150
     notional = 10000000000000000000  # 10
@@ -93,8 +95,8 @@ def test_notional_current_when_fraction_less_than_one(position):
     # when long
     is_long = True
     expect = 3750000000000000000
-    pos = (notional, debt, is_long, liquidated, entry_price)
-    actual = position.notionalCurrent(pos, fraction, oi, oi, current_price,
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
+    actual = position.notionalWithPnl(pos, fraction, oi, oi, current_price,
                                       cap_payoff)
     assert expect == actual
 
@@ -102,13 +104,13 @@ def test_notional_current_when_fraction_less_than_one(position):
     # when short
     is_long = False
     expect = 1250000000000000000
-    pos = (notional, debt, is_long, liquidated, entry_price)
-    actual = position.notionalCurrent(pos, fraction, oi, oi, current_price,
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
+    actual = position.notionalWithPnl(pos, fraction, oi, oi, current_price,
                                       cap_payoff)
     assert expect == actual
 
 
-def test_notional_current_when_payoff_greater_than_cap(position):
+def test_notional_with_pnl_when_payoff_greater_than_cap(position):
     entry_price = 100000000000000000000  # 100
     current_price = 800000000000000000000  # 800
     notional = 10000000000000000000  # 10
@@ -123,13 +125,13 @@ def test_notional_current_when_payoff_greater_than_cap(position):
     # when long
     is_long = True
     expect = 60000000000000000000
-    pos = (notional, debt, is_long, liquidated, entry_price)
-    actual = position.notionalCurrent(pos, fraction, oi, oi, current_price,
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
+    actual = position.notionalWithPnl(pos, fraction, oi, oi, current_price,
                                       cap_payoff)
     assert expect == actual
 
 
-def test_notional_current_when_underwater(position):
+def test_notional_with_pnl_when_underwater(position):
     entry_price = 100000000000000000000  # 100
     notional = 10000000000000000000  # 10
     debt = 8000000000000000000  # 8
@@ -143,13 +145,13 @@ def test_notional_current_when_underwater(position):
     is_long = False
     current_price = 225000000000000000000  # 225
     expect = debt
-    pos = (notional, debt, is_long, liquidated, entry_price)
-    actual = position.notionalCurrent(pos, fraction, oi, oi, current_price,
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
+    actual = position.notionalWithPnl(pos, fraction, oi, oi, current_price,
                                       cap_payoff)
     assert expect == actual
 
 
-def test_notional_current_when_oi_zero(position):
+def test_notional_with_pnl_when_oi_zero(position):
     current_price = 75000000000000000000  # 75
     entry_price = 100000000000000000000  # 100
     notional = 0  # 0
@@ -163,15 +165,15 @@ def test_notional_current_when_oi_zero(position):
     # check notional returns debt when oi is zero and is long
     is_long = True
     expect = debt
-    pos = (notional, debt, is_long, liquidated, entry_price)
-    actual = position.notionalCurrent(pos, fraction, oi, oi, current_price,
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
+    actual = position.notionalWithPnl(pos, fraction, oi, oi, current_price,
                                       cap_payoff)
     assert expect == actual
 
     # check notional returns the debt when oi is zero and is short
     is_long = False
     expect = debt
-    pos = (notional, debt, is_long, liquidated, entry_price)
-    actual = position.notionalCurrent(pos, fraction, oi, oi, current_price,
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
+    actual = position.notionalWithPnl(pos, fraction, oi, oi, current_price,
                                       cap_payoff)
     assert expect == actual

--- a/tests/libraries/position/test_notional.py
+++ b/tests/libraries/position/test_notional.py
@@ -1,87 +1,141 @@
-def test_notional(position):
+def test_notional_initial(position):
     entry_price = 100000000000000000000  # 100
-    current_price = 150000000000000000000  # 150
-    oi = 10000000000000000000  # 10
+    notional = 10000000000000000000  # 10
     debt = 2000000000000000000  # 2
     liquidated = False
 
     fraction = 1000000000000000000  # 1
-    cap_payoff = 5000000000000000000  # 5
 
-    # check notional is oi + oi * (current_price/entry_price - 1)
+    # check initial notional is oi * entry_price = notional
     # when long
     is_long = True
-    expect = 15000000000000000000
-    pos = (oi, debt, is_long, liquidated, entry_price)
-    actual = position.notional(pos, fraction, oi, oi, current_price,
-                               cap_payoff)
+    expect = notional
+    pos = (notional, debt, is_long, liquidated, entry_price)
+    actual = position.notionalInitial(pos, fraction)
     assert expect == actual
 
-    # check value is oi - oi * (current_price/entry_price - 1)
+    # check initial notional is oi * entry_price = notional
     # when short
     is_long = False
-    expect = 5000000000000000000
-    pos = (oi, debt, is_long, liquidated, entry_price)
-    actual = position.notional(pos, fraction, oi, oi, current_price,
-                               cap_payoff)
+    expect = notional
+    pos = (notional, debt, is_long, liquidated, entry_price)
+    actual = position.notionalInitial(pos, fraction)
     assert expect == actual
 
 
-def test_notional_when_fraction_less_than_one(position):
+def test_notional_initial_when_fraction_less_than_one(position):
     entry_price = 100000000000000000000  # 100
-    current_price = 150000000000000000000  # 150
-    oi = 10000000000000000000  # 10
+    notional = 10000000000000000000  # 10
     debt = 2000000000000000000  # 2
     liquidated = False
 
     fraction = 250000000000000000  # 0.25
-    cap_payoff = 5000000000000000000  # 5
 
-    # check notional is oi + oi * (current_price/entry_price - 1)
+    # check initial notional is oi * entry_price = notional
     # when long
     is_long = True
-    expect = 3750000000000000000
-    pos = (oi, debt, is_long, liquidated, entry_price)
-    actual = position.notional(pos, fraction, oi, oi, current_price,
-                               cap_payoff)
+    expect = 2500000000000000000
+    pos = (notional, debt, is_long, liquidated, entry_price)
+    actual = position.notionalInitial(pos, fraction)
     assert expect == actual
 
-    # check value is oi - oi * (current_price/entry_price - 1)
+    # check initial notional is oi * entry_price = notional
     # when short
     is_long = False
-    expect = 1250000000000000000
-    pos = (oi, debt, is_long, liquidated, entry_price)
-    actual = position.notional(pos, fraction, oi, oi, current_price,
-                               cap_payoff)
+    expect = 2500000000000000000
+    pos = (notional, debt, is_long, liquidated, entry_price)
+    actual = position.notionalInitial(pos, fraction)
     assert expect == actual
 
 
-def test_notional_when_payoff_greater_than_cap(position):
+def test_notional_current(position):
     entry_price = 100000000000000000000  # 100
-    current_price = 800000000000000000000  # 800
-    oi = 10000000000000000000  # 10
+    current_price = 150000000000000000000  # 150
+    notional = 10000000000000000000  # 10
     debt = 2000000000000000000  # 2
     liquidated = False
 
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
     fraction = 1000000000000000000  # 1
     cap_payoff = 5000000000000000000  # 5
 
-    # check notional is oi + oi * (current_price/entry_price - 1)
+    # check current notional is oi * current_price
     # when long
     is_long = True
-    expect = 60000000000000000000
-    pos = (oi, debt, is_long, liquidated, entry_price)
-    actual = position.notional(pos, fraction, oi, oi, current_price,
-                               cap_payoff)
+    expect = 15000000000000000000
+    pos = (notional, debt, is_long, liquidated, entry_price)
+    actual = position.notionalCurrent(pos, fraction, oi, oi, current_price,
+                                      cap_payoff)
+    assert expect == actual
+
+    # check current notional is 2 * oi * entry_price - oi * current_price
+    # when short
+    is_long = False
+    expect = 5000000000000000000
+    pos = (notional, debt, is_long, liquidated, entry_price)
+    actual = position.notionalCurrent(pos, fraction, oi, oi, current_price,
+                                      cap_payoff)
     assert expect == actual
 
 
-def test_notional_when_underwater(position):
+def test_notional_current_when_fraction_less_than_one(position):
     entry_price = 100000000000000000000  # 100
-    oi = 10000000000000000000  # 10
+    current_price = 150000000000000000000  # 150
+    notional = 10000000000000000000  # 10
+    debt = 2000000000000000000  # 2
+    liquidated = False
+
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
+    fraction = 250000000000000000  # 0.25
+    cap_payoff = 5000000000000000000  # 5
+
+    # check notional is oi * current_price
+    # when long
+    is_long = True
+    expect = 3750000000000000000
+    pos = (notional, debt, is_long, liquidated, entry_price)
+    actual = position.notionalCurrent(pos, fraction, oi, oi, current_price,
+                                      cap_payoff)
+    assert expect == actual
+
+    # check notional is 2 * oi * entry_price - oi * current_price
+    # when short
+    is_long = False
+    expect = 1250000000000000000
+    pos = (notional, debt, is_long, liquidated, entry_price)
+    actual = position.notionalCurrent(pos, fraction, oi, oi, current_price,
+                                      cap_payoff)
+    assert expect == actual
+
+
+def test_notional_current_when_payoff_greater_than_cap(position):
+    entry_price = 100000000000000000000  # 100
+    current_price = 800000000000000000000  # 800
+    notional = 10000000000000000000  # 10
+    debt = 2000000000000000000  # 2
+    liquidated = False
+
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
+    fraction = 1000000000000000000  # 1
+    cap_payoff = 5000000000000000000  # 5
+
+    # check notional is oi * entry_price * (1 + cap_payoff)
+    # when long
+    is_long = True
+    expect = 60000000000000000000
+    pos = (notional, debt, is_long, liquidated, entry_price)
+    actual = position.notionalCurrent(pos, fraction, oi, oi, current_price,
+                                      cap_payoff)
+    assert expect == actual
+
+
+def test_notional_current_when_underwater(position):
+    entry_price = 100000000000000000000  # 100
+    notional = 10000000000000000000  # 10
     debt = 8000000000000000000  # 8
     liquidated = False
 
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
     fraction = 1000000000000000000  # 1
     cap_payoff = 5000000000000000000  # 5
 
@@ -89,34 +143,35 @@ def test_notional_when_underwater(position):
     is_long = False
     current_price = 225000000000000000000  # 225
     expect = debt
-    pos = (oi, debt, is_long, liquidated, entry_price)
-    actual = position.notional(pos, fraction, oi, oi, current_price,
-                               cap_payoff)
+    pos = (notional, debt, is_long, liquidated, entry_price)
+    actual = position.notionalCurrent(pos, fraction, oi, oi, current_price,
+                                      cap_payoff)
     assert expect == actual
 
 
-def test_notional_when_oi_zero(position):
+def test_notional_current_when_oi_zero(position):
     current_price = 75000000000000000000  # 75
     entry_price = 100000000000000000000  # 100
-    oi = 0  # 0
+    notional = 0  # 0
     debt = 2000000000000000000  # 2
     liquidated = False
 
+    oi = (notional / entry_price) * 1000000000000000000  # 0
     fraction = 1000000000000000000  # 1
     cap_payoff = 5000000000000000000  # 5
 
     # check notional returns debt when oi is zero and is long
     is_long = True
     expect = debt
-    pos = (oi, debt, is_long, liquidated, entry_price)
-    actual = position.notional(pos, fraction, oi, oi, current_price,
-                               cap_payoff)
+    pos = (notional, debt, is_long, liquidated, entry_price)
+    actual = position.notionalCurrent(pos, fraction, oi, oi, current_price,
+                                      cap_payoff)
     assert expect == actual
 
     # check notional returns the debt when oi is zero and is short
     is_long = False
     expect = debt
-    pos = (oi, debt, is_long, liquidated, entry_price)
-    actual = position.notional(pos, fraction, oi, oi, current_price,
-                               cap_payoff)
+    pos = (notional, debt, is_long, liquidated, entry_price)
+    actual = position.notionalCurrent(pos, fraction, oi, oi, current_price,
+                                      cap_payoff)
     assert expect == actual

--- a/tests/libraries/position/test_oi.py
+++ b/tests/libraries/position/test_oi.py
@@ -1,40 +1,43 @@
 def test_oi_current(position):
-    # NOTE: oi_initial = oi_shares
+    # NOTE: oi = pos.oi_shares
     is_long = True
     liquidated = False
     entry_price = 100000000000000000000  # 100
-    oi_shares = 10000000000000000000  # 10
+    notional = 10000000000000000000  # 10
     debt = 2000000000000000000  # 2
     fraction = 1000000000000000000  # 1
+
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
 
     # lost 3 from total oi due to funding
     total_oi = 12000000000000000000  # 12
     total_oi_shares = 15000000000000000000  # 15
 
     # check oi is pro-rata shares of total oi
-    expect = int((total_oi * oi_shares / total_oi_shares) * (fraction / 1e18))
-    pos = (oi_shares, debt, is_long, liquidated, entry_price)
+    expect = int((total_oi * oi / total_oi_shares) * (fraction / 1e18))
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.oiCurrent(pos, fraction, total_oi, total_oi_shares)
-
     assert expect == actual
 
 
 def test_oi_current_when_fraction_less_than_one(position):
-    # NOTE: oi_initial = oi_shares
+    # NOTE: oi = pos.oi_shares
     is_long = True
     liquidated = False
     entry_price = 100000000000000000000  # 100
-    oi_shares = 10000000000000000000  # 10
+    notional = 10000000000000000000  # 10
     debt = 2000000000000000000  # 2
     fraction = 250000000000000000  # 0.25
+
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
 
     # lost 3 from total oi due to funding
     total_oi = 12000000000000000000  # 12
     total_oi_shares = 15000000000000000000  # 15
 
     # check oi is pro-rata shares of total oi
-    expect = int((total_oi * oi_shares / total_oi_shares) * (fraction / 1e18))
-    pos = (oi_shares, debt, is_long, liquidated, entry_price)
+    expect = int((total_oi * oi / total_oi_shares) * (fraction / 1e18))
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.oiCurrent(pos, fraction, total_oi, total_oi_shares)
     assert expect == actual
 
@@ -49,7 +52,7 @@ def test_oi_current_when_total_oi_or_oi_shares_zero(position):
     3. oi_shares, total_oi, total_oi_shares = 0
     4. oi_shares, total_oi = 0; total_oi_shares != 0
     """
-    # NOTE: oi_initial = oi_shares
+    # NOTE: oi = pos.oi_shares
     is_long = True
     liquidated = False
     entry_price = 100000000000000000000  # 100
@@ -57,42 +60,43 @@ def test_oi_current_when_total_oi_or_oi_shares_zero(position):
     fraction = 1000000000000000000  # 1
 
     # 1. lost it all due to funding (t -> infty)
-    oi_shares = 10000000000000000000  # 10
+    notional = 10000000000000000000  # 10
     total_oi = 0  # 0
     total_oi_shares = 15000000000000000000  # 15
 
     # check oi is zero
     expect = 0
-    pos = (oi_shares, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.oiCurrent(pos, fraction, total_oi, total_oi_shares)
     assert expect == actual
 
-    # 2. unwound all position's shares of oi
-    oi_shares = 0  # 0
+    # 2. unwound all of position oi
+    notional = 0  # 0
     total_oi = 4000000000000000000  # 4
     total_oi_shares = 5000000000000000000  # 5
 
     expect = 0
-    pos = (oi_shares, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.oiCurrent(pos, fraction, total_oi, total_oi_shares)
     assert expect == actual
 
     # 3. all oi has been unwound
-    oi_shares = 0  # 0
+    notional = 0  # 0
     total_oi = 0  # 0
     total_oi_shares = 0  # 0
 
     expect = 0
-    pos = (oi_shares, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.oiCurrent(pos, fraction, total_oi, total_oi_shares)
     assert expect == actual
 
     # 4. position has been liquidated
-    oi_shares = 0  # 0
+    notional = 0  # 0
     total_oi = 0  # 0
     total_oi_shares = 5000000000000000000  # 5
+    liquidated = True
 
     expect = 0
-    pos = (oi_shares, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.oiCurrent(pos, fraction, total_oi, total_oi_shares)
     assert expect == actual

--- a/tests/libraries/position/test_oi.py
+++ b/tests/libraries/position/test_oi.py
@@ -15,7 +15,7 @@ def test_oi_current(position):
 
     # check oi is pro-rata shares of total oi
     expect = int((total_oi * oi / total_oi_shares) * (fraction / 1e18))
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.oiCurrent(pos, fraction, total_oi, total_oi_shares)
     assert expect == actual
 
@@ -37,7 +37,7 @@ def test_oi_current_when_fraction_less_than_one(position):
 
     # check oi is pro-rata shares of total oi
     expect = int((total_oi * oi / total_oi_shares) * (fraction / 1e18))
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.oiCurrent(pos, fraction, total_oi, total_oi_shares)
     assert expect == actual
 
@@ -63,10 +63,11 @@ def test_oi_current_when_total_oi_or_oi_shares_zero(position):
     notional = 10000000000000000000  # 10
     total_oi = 0  # 0
     total_oi_shares = 15000000000000000000  # 15
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
 
     # check oi is zero
     expect = 0
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.oiCurrent(pos, fraction, total_oi, total_oi_shares)
     assert expect == actual
 
@@ -74,9 +75,10 @@ def test_oi_current_when_total_oi_or_oi_shares_zero(position):
     notional = 0  # 0
     total_oi = 4000000000000000000  # 4
     total_oi_shares = 5000000000000000000  # 5
+    oi = (notional / entry_price) * 1000000000000000000  # 0
 
     expect = 0
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.oiCurrent(pos, fraction, total_oi, total_oi_shares)
     assert expect == actual
 
@@ -84,9 +86,10 @@ def test_oi_current_when_total_oi_or_oi_shares_zero(position):
     notional = 0  # 0
     total_oi = 0  # 0
     total_oi_shares = 0  # 0
+    oi = (notional / entry_price) * 1000000000000000000  # 0
 
     expect = 0
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.oiCurrent(pos, fraction, total_oi, total_oi_shares)
     assert expect == actual
 
@@ -95,8 +98,9 @@ def test_oi_current_when_total_oi_or_oi_shares_zero(position):
     total_oi = 0  # 0
     total_oi_shares = 5000000000000000000  # 5
     liquidated = True
+    oi = (notional / entry_price) * 1000000000000000000  # 0
 
     expect = 0
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.oiCurrent(pos, fraction, total_oi, total_oi_shares)
     assert expect == actual

--- a/tests/libraries/position/test_positions.py
+++ b/tests/libraries/position/test_positions.py
@@ -17,10 +17,10 @@ def test_positions_setter(position, alice):
     is_long = True
     liquidated = False
     entry_price = 100000000000000000000  # 100
-    oi = 10000000000000000000  # 10
+    notional = 10000000000000000000  # 10
     debt = 8000000000000000000  # 8
 
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     position.set(owner, id, pos)
 
     # pos key
@@ -40,10 +40,10 @@ def test_positions_getter(position, bob):
     is_long = True
     liquidated = False
     entry_price = 100000000000000000000  # 100
-    oi = 10000000000000000000  # 10
+    notional = 10000000000000000000  # 10
     debt = 8000000000000000000  # 8
 
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     position.set(owner, id, pos)
 
     # check retrieved position is expected

--- a/tests/libraries/position/test_positions.py
+++ b/tests/libraries/position/test_positions.py
@@ -20,7 +20,9 @@ def test_positions_setter(position, alice):
     notional = 10000000000000000000  # 10
     debt = 8000000000000000000  # 8
 
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
+
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     position.set(owner, id, pos)
 
     # pos key
@@ -42,8 +44,9 @@ def test_positions_getter(position, bob):
     entry_price = 100000000000000000000  # 100
     notional = 10000000000000000000  # 10
     debt = 8000000000000000000  # 8
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
 
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     position.set(owner, id, pos)
 
     # check retrieved position is expected

--- a/tests/libraries/position/test_value.py
+++ b/tests/libraries/position/test_value.py
@@ -1,26 +1,27 @@
 def test_value(position):
     entry_price = 100000000000000000000  # 100
     current_price = 150000000000000000000  # 150
-    oi = 10000000000000000000  # 10
+    notional = 10000000000000000000  # 10
     debt = 2000000000000000000  # 2
     liquidated = False
 
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
     fraction = 1000000000000000000  # 1
     cap_payoff = 5000000000000000000  # 5
 
-    # check value is oi - debt + oi * (current_price/entry_price - 1)
+    # check value is oi * current_price - debt
     # when long
     is_long = True
     expect = 13000000000000000000
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.value(pos, fraction, oi, oi, current_price, cap_payoff)
     assert expect == actual
 
-    # check value is oi - debt - oi * (current_price/entry_price - 1)
+    # check value is 2 * oi * entry_price - debt - oi * current_price
     # when short
     is_long = False
     expect = 3000000000000000000
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.value(pos, fraction, oi, oi, current_price, cap_payoff)
     assert expect == actual
 
@@ -28,26 +29,27 @@ def test_value(position):
 def test_value_when_fraction_less_than_one(position):
     entry_price = 100000000000000000000  # 100
     current_price = 150000000000000000000  # 150
-    oi = 10000000000000000000  # 10
+    notional = 10000000000000000000  # 10
     debt = 2000000000000000000  # 2
     liquidated = False
 
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
     fraction = 250000000000000000  # 0.25
     cap_payoff = 5000000000000000000  # 5
 
-    # check value is oi - debt + oi * (current_price/entry_price - 1)
+    # check value is oi * current_price - debt
     # when long
     is_long = True
     expect = 3250000000000000000
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.value(pos, fraction, oi, oi, current_price, cap_payoff)
     assert expect == actual
 
-    # check value is oi - debt - oi * (current_price/entry_price - 1)
+    # check value is 2 * oi * entry_price - debt - oi * current_price
     # when short
     is_long = False
     expect = 750000000000000000
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.value(pos, fraction, oi, oi, current_price, cap_payoff)
     assert expect == actual
 
@@ -55,28 +57,30 @@ def test_value_when_fraction_less_than_one(position):
 def test_value_when_payoff_greater_than_cap(position):
     entry_price = 100000000000000000000  # 100
     current_price = 800000000000000000000  # 800
-    oi = 10000000000000000000  # 10
+    notional = 10000000000000000000  # 10
     debt = 2000000000000000000  # 2
     liquidated = False
 
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
     fraction = 1000000000000000000  # 1
     cap_payoff = 5000000000000000000  # 5
 
-    # check value is oi - debt + oi * (current_price/entry_price - 1)
+    # check value is oi * entry_price * (1 + cap_payoff) - debt
     # when long
     is_long = True
     expect = 58000000000000000000
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.value(pos, fraction, oi, oi, current_price, cap_payoff)
     assert expect == actual
 
 
 def test_value_when_underwater(position):
     entry_price = 100000000000000000000  # 100
-    oi = 10000000000000000000  # 10
+    notional = 10000000000000000000  # 10
     debt = 8000000000000000000  # 8
     liquidated = False
 
+    oi = (notional / entry_price) * 1000000000000000000  # 0.1
     fraction = 1000000000000000000  # 1
     cap_payoff = 5000000000000000000  # 5
 
@@ -84,7 +88,7 @@ def test_value_when_underwater(position):
     is_long = True
     current_price = 75000000000000000000  # 75
     expect = 0
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.value(pos, fraction, oi, oi, current_price, cap_payoff)
     assert expect == actual
 
@@ -92,7 +96,7 @@ def test_value_when_underwater(position):
     is_long = False
     current_price = 125000000000000000000  # 125
     expect = 0
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.value(pos, fraction, oi, oi, current_price, cap_payoff)
     assert expect == actual
 
@@ -100,23 +104,24 @@ def test_value_when_underwater(position):
 def test_value_when_oi_zero(position):
     current_price = 75000000000000000000  # 75
     entry_price = 100000000000000000000  # 100
-    oi = 0  # 0
+    notional = 0  # 0
     debt = 2000000000000000000  # 2
     liquidated = False
 
+    oi = (notional / entry_price) * 1000000000000000000  # 0
     fraction = 1000000000000000000  # 1
     cap_payoff = 5000000000000000000  # 5
 
     # check value returns zero when oi is zero and is long
     is_long = True
     expect = 0
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.value(pos, fraction, oi, oi, current_price, cap_payoff)
     assert expect == actual
 
     # check value returns zero when oi is zero and is short
     is_long = False
     expect = 0
-    pos = (oi, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price)
     actual = position.value(pos, fraction, oi, oi, current_price, cap_payoff)
     assert expect == actual

--- a/tests/libraries/position/test_value.py
+++ b/tests/libraries/position/test_value.py
@@ -1,3 +1,5 @@
+# TODO: test when oi = notional / mid_price
+
 def test_value(position):
     entry_price = 100000000000000000000  # 100
     current_price = 150000000000000000000  # 150
@@ -13,7 +15,7 @@ def test_value(position):
     # when long
     is_long = True
     expect = 13000000000000000000
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.value(pos, fraction, oi, oi, current_price, cap_payoff)
     assert expect == actual
 
@@ -21,7 +23,7 @@ def test_value(position):
     # when short
     is_long = False
     expect = 3000000000000000000
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.value(pos, fraction, oi, oi, current_price, cap_payoff)
     assert expect == actual
 
@@ -41,7 +43,7 @@ def test_value_when_fraction_less_than_one(position):
     # when long
     is_long = True
     expect = 3250000000000000000
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.value(pos, fraction, oi, oi, current_price, cap_payoff)
     assert expect == actual
 
@@ -49,7 +51,7 @@ def test_value_when_fraction_less_than_one(position):
     # when short
     is_long = False
     expect = 750000000000000000
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.value(pos, fraction, oi, oi, current_price, cap_payoff)
     assert expect == actual
 
@@ -69,7 +71,7 @@ def test_value_when_payoff_greater_than_cap(position):
     # when long
     is_long = True
     expect = 58000000000000000000
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.value(pos, fraction, oi, oi, current_price, cap_payoff)
     assert expect == actual
 
@@ -88,7 +90,7 @@ def test_value_when_underwater(position):
     is_long = True
     current_price = 75000000000000000000  # 75
     expect = 0
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.value(pos, fraction, oi, oi, current_price, cap_payoff)
     assert expect == actual
 
@@ -96,7 +98,7 @@ def test_value_when_underwater(position):
     is_long = False
     current_price = 125000000000000000000  # 125
     expect = 0
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.value(pos, fraction, oi, oi, current_price, cap_payoff)
     assert expect == actual
 
@@ -115,13 +117,13 @@ def test_value_when_oi_zero(position):
     # check value returns zero when oi is zero and is long
     is_long = True
     expect = 0
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.value(pos, fraction, oi, oi, current_price, cap_payoff)
     assert expect == actual
 
     # check value returns zero when oi is zero and is short
     is_long = False
     expect = 0
-    pos = (notional, debt, is_long, liquidated, entry_price)
+    pos = (notional, debt, is_long, liquidated, entry_price, oi)
     actual = position.value(pos, fraction, oi, oi, current_price, cap_payoff)
     assert expect == actual

--- a/tests/markets/conftest.py
+++ b/tests/markets/conftest.py
@@ -148,7 +148,7 @@ def mock_feed(create_mock_feed):
 
 @pytest.fixture(scope="module", params=[(
     1220000000000,  # k
-    1000000000000000000,  # lmbda
+    500000000000000000,  # lmbda
     2500000000000000,  # delta
     5000000000000000000,  # capPayoff
     800000000000000000000000,  # capOi

--- a/tests/markets/conftest.py
+++ b/tests/markets/conftest.py
@@ -182,7 +182,7 @@ def create_market(gov, ovl):
 
 @pytest.fixture(scope="module", params=[(
     1220000000000,  # k
-    1000000000000000000,  # lmbda
+    500000000000000000,  # lmbda
     2500000000000000,  # delta
     5000000000000000000,  # capPayoff
     800000000000000000000000,  # capNotional

--- a/tests/markets/conftest.py
+++ b/tests/markets/conftest.py
@@ -185,7 +185,7 @@ def create_market(gov, ovl):
     1000000000000000000,  # lmbda
     2500000000000000,  # delta
     5000000000000000000,  # capPayoff
-    800000000000000000000000,  # capOi
+    800000000000000000000000,  # capNotional
     5000000000000000000,  # capLeverage
     2592000,  # circuitBreakerWindow
     66670000000000000000000,  # circuitBreakerMintTarget

--- a/tests/markets/test_build.py
+++ b/tests/markets/test_build.py
@@ -3,7 +3,7 @@ from pytest import approx
 from brownie import chain, reverts
 from brownie.test import given, strategy
 from decimal import Decimal
-from math import exp, log
+from math import log
 from random import randint
 
 from .utils import calculate_position_info, get_position_key, mid_from_feed

--- a/tests/markets/test_build.py
+++ b/tests/markets/test_build.py
@@ -3,6 +3,7 @@ from pytest import approx
 from brownie import chain, reverts
 from brownie.test import given, strategy
 from decimal import Decimal
+from math import exp, log
 from random import randint
 
 from .utils import calculate_position_info, get_position_key, mid_from_feed
@@ -13,9 +14,6 @@ from .utils import calculate_position_info, get_position_key, mid_from_feed
 @pytest.fixture(autouse=True)
 def isolation(fn_isolation):
     pass
-
-
-# TODO: test pos liquidatable on build revert
 
 
 @given(
@@ -540,6 +538,71 @@ def test_build_reverts_when_oi_greater_than_cap(market, ovl, alice, is_long):
     actual_pos_id = market.nextPositionId()
 
     assert expect_pos_id == actual_pos_id
+
+
+@given(is_long=strategy('bool'))
+def test_build_reverts_when_liquidatable(market, feed, ovl, alice, is_long):
+    # get position key/id related info
+    expect_pos_id = market.nextPositionId()
+    leverage = Decimal(5)
+
+    tol = 1e-2
+
+    # priors
+    delta = Decimal(market.delta()) / Decimal(1e18)
+    lmbda = Decimal(market.lmbda()) / Decimal(1e18)
+    maintenance_fraction = Decimal(market.maintenanceMarginFraction()) \
+        / Decimal(1e18)
+
+    # calculate the liquidation price factor
+    # then infer market impact required to slip to this price
+    # ask/mid = 1 - mm + 1/L
+    # bid/mid = 1 + mm - 1/L
+    if is_long:
+        liq_price_factor = 1 - maintenance_fraction + Decimal(1)/leverage
+    else:
+        liq_price_factor = 1 + maintenance_fraction - Decimal(1)/leverage
+
+    # Use mid price to calculate liquidation price
+    data = feed.latest()
+    mid_price = Decimal(mid_from_feed(data))
+    liq_price = mid_price * liq_price_factor
+
+    # ask/mid ~ e**(delta + lmbda * volume)
+    # bid/mid = e**(-delta - lmbda * volume)
+    if is_long:
+        volume = (Decimal(log(liq_price / mid_price)) - delta) / lmbda
+    else:
+        volume = (Decimal(log(mid_price / liq_price)) - delta) / lmbda
+
+    # calculate notional from required market impact
+    cap_notional = market.capNotionalAdjustedForBounds(data,
+                                                       market.capNotional())
+
+    input_leverage = int(leverage * Decimal(1e18))
+    input_is_long = is_long
+
+    # NOTE: slippage tests in test_slippage.py
+    # NOTE: setting to min/max here, so never reverts with slippage>max
+    input_price_limit = 2**256-1 if is_long else 0
+
+    # approve market for spending before build. use max
+    ovl.approve(market, 2**256 - 1, {"from": alice})
+
+    # check build reverts when position is liquidatable
+    input_notional = Decimal(cap_notional) * volume * Decimal(1 + tol)
+    input_collateral = int((input_notional / leverage))
+    with reverts("OVLV1:liquidatable"):
+        _ = market.build(input_collateral, input_leverage, input_is_long,
+                         input_price_limit, {"from": alice})
+
+    # check build succeeds when position is not liquidatable
+    input_notional = Decimal(cap_notional) * volume * Decimal(1 - tol)
+    input_collateral = int(input_notional / leverage)
+    market.build(input_collateral, input_leverage, input_is_long,
+                 input_price_limit, {"from": alice})
+
+    assert market.nextPositionId() == expect_pos_id + 1
 
 
 def test_multiple_build_creates_multiple_positions(market, factory, ovl,

--- a/tests/markets/test_build.py
+++ b/tests/markets/test_build.py
@@ -73,7 +73,7 @@ def test_build_creates_position(market, feed, ovl, alice, oi, leverage,
     expect_pos_key = get_position_key(alice.address, expect_pos_id)
     actual_pos = market.positions(expect_pos_key)
     (actual_oi_initial, actual_debt, actual_is_long, actual_liquidated,
-     actual_entry_price) = actual_pos
+     actual_entry_price, _) = actual_pos
 
     assert actual_is_long == expect_is_long
     assert actual_liquidated == expect_liquidated
@@ -600,7 +600,7 @@ def test_multiple_build_creates_multiple_positions(market, factory, ovl,
         actual_pos_alice = market.positions(
             get_position_key(alice.address, expect_pos_id_alice))
         (actual_oi_alice, actual_debt_alice, actual_is_long_alice,
-         actual_liquidated_alice, _) = actual_pos_alice
+         actual_liquidated_alice, _, _) = actual_pos_alice
 
         assert actual_is_long_alice == expect_is_long_alice
         assert actual_liquidated_alice == expect_liquidated_alice
@@ -639,7 +639,7 @@ def test_multiple_build_creates_multiple_positions(market, factory, ovl,
         actual_pos_bob = market.positions(
             get_position_key(bob.address, expect_pos_id_bob))
         (actual_oi_bob, actual_debt_bob, actual_is_long_bob,
-         actual_liquidated_bob, _) = actual_pos_bob
+         actual_liquidated_bob, _, _) = actual_pos_bob
 
         assert actual_is_long_bob == expect_is_long_bob
         assert actual_liquidated_bob is expect_liquidated_bob

--- a/tests/markets/test_build.py
+++ b/tests/markets/test_build.py
@@ -546,7 +546,8 @@ def test_build_reverts_when_liquidatable(market, feed, ovl, alice, is_long):
     expect_pos_id = market.nextPositionId()
     leverage = Decimal(5)
 
-    tol = 1e-2
+    # TODO: why tol so high needed
+    tol = 5e-2
 
     # priors
     delta = Decimal(market.delta()) / Decimal(1e18)

--- a/tests/markets/test_build.py
+++ b/tests/markets/test_build.py
@@ -5,7 +5,7 @@ from brownie.test import given, strategy
 from decimal import Decimal
 from random import randint
 
-from .utils import calculate_position_info, get_position_key
+from .utils import calculate_position_info, get_position_key, mid_from_feed
 
 
 # NOTE: Tests passing with isolation fixture
@@ -15,19 +15,23 @@ def isolation(fn_isolation):
     pass
 
 
+# TODO: test pos liquidatable on build revert
+
+
 @given(
-    oi=strategy('decimal', min_value='0.001', max_value='800000', places=3),
+    notional=strategy('decimal', min_value='0.001', max_value='80000',
+                      places=3),
     leverage=strategy('decimal', min_value='1.0', max_value='5.0', places=3),
     is_long=strategy('bool'))
-def test_build_creates_position(market, feed, ovl, alice, oi, leverage,
+def test_build_creates_position(market, feed, ovl, alice, notional, leverage,
                                 is_long):
     # get position key/id related info
     expect_pos_id = market.nextPositionId()
 
     # calculate expected pos info data
     trading_fee_rate = Decimal(market.tradingFeeRate() / 1e18)
-    collateral, oi, debt, trade_fee \
-        = calculate_position_info(oi, leverage, trading_fee_rate)
+    collateral, notional, debt, trade_fee \
+        = calculate_position_info(notional, leverage, trading_fee_rate)
 
     # input values for tx
     input_collateral = int((collateral) * Decimal(1e18))
@@ -54,10 +58,15 @@ def test_build_creates_position(market, feed, ovl, alice, oi, leverage,
     actual_next_pos_id = market.nextPositionId()
     assert actual_next_pos_id == expect_next_pos_id
 
-    # calculate expected entry price
+    # calculate oi and expected entry price
     # NOTE: ask(), bid() tested in test_price.py
     data = feed.latest()
-    cap_oi = Decimal(market.capOiAdjustedForBounds(data, market.capOi())/1e18)
+    mid = Decimal(mid_from_feed(data)) / Decimal(1e18)
+    oi = notional / mid
+    cap_notional = Decimal(
+        market.capNotionalAdjustedForBounds(data, market.capNotional())) \
+        / Decimal(1e18)
+    cap_oi = (Decimal(cap_notional) / mid)
     volume = int((oi / cap_oi) * Decimal(1e18))  # TODO: circuit breaker adj
     price = market.ask(data, volume) if is_long \
         else market.bid(data, volume)
@@ -66,18 +75,20 @@ def test_build_creates_position(market, feed, ovl, alice, oi, leverage,
     expect_is_long = is_long
     expect_liquidated = False
     expect_entry_price = price
+    expect_notional_initial = int(notional * Decimal(1e18))
     expect_oi_initial = int(oi * Decimal(1e18))
     expect_debt = int(debt * Decimal(1e18))
 
     # check position info
     expect_pos_key = get_position_key(alice.address, expect_pos_id)
     actual_pos = market.positions(expect_pos_key)
-    (actual_oi_initial, actual_debt, actual_is_long, actual_liquidated,
-     actual_entry_price, _) = actual_pos
+    (actual_notional_initial, actual_debt, actual_is_long, actual_liquidated,
+     actual_entry_price, actual_oi_initial) = actual_pos
 
     assert actual_is_long == expect_is_long
     assert actual_liquidated == expect_liquidated
     assert int(actual_entry_price) == approx(expect_entry_price)
+    assert int(actual_notional_initial) == approx(expect_notional_initial)
     assert int(actual_oi_initial) == approx(expect_oi_initial)
     assert int(actual_debt) == approx(expect_debt)
 
@@ -92,14 +103,15 @@ def test_build_creates_position(market, feed, ovl, alice, oi, leverage,
 
 
 @given(
-    oi=strategy('decimal', min_value='0.001', max_value='800000', places=3),
+    notional=strategy('decimal', min_value='0.001', max_value='80000',
+                      places=3),
     leverage=strategy('decimal', min_value='1.0', max_value='5.0', places=3),
     is_long=strategy('bool'))
-def test_build_adds_oi(market, ovl, alice, oi, leverage, is_long):
+def test_build_adds_oi(market, feed, ovl, alice, notional, leverage, is_long):
     # calculate expected pos info data
     trading_fee_rate = Decimal(market.tradingFeeRate() / 1e18)
-    collateral, oi, debt, trade_fee \
-        = calculate_position_info(oi, leverage, trading_fee_rate)
+    collateral, notional, debt, trade_fee \
+        = calculate_position_info(notional, leverage, trading_fee_rate)
 
     # input values for tx
     input_collateral = int(collateral * Decimal(1e18))
@@ -124,6 +136,11 @@ def test_build_adds_oi(market, ovl, alice, oi, leverage, is_long):
     _ = market.build(input_collateral, input_leverage, input_is_long,
                      input_price_limit, {"from": alice})
 
+    # calculate oi
+    data = feed.latest()
+    mid = Decimal(mid_from_feed(data)) / Decimal(1e18)
+    oi = notional / mid
+
     # calculate expected oi info data
     expect_oi += int(oi * Decimal(1e18))
     expect_oi_shares += int(oi * Decimal(1e18))
@@ -138,7 +155,7 @@ def test_build_adds_oi(market, ovl, alice, oi, leverage, is_long):
 
 def test_build_updates_market(market, ovl, alice):
     # position build attributes
-    oi_initial = Decimal(1000)
+    notional_initial = Decimal(1000)
     leverage = Decimal(1.5)
     is_long = True
 
@@ -151,7 +168,7 @@ def test_build_updates_market(market, ovl, alice):
     # calculate expected pos info data
     trading_fee_rate = Decimal(market.tradingFeeRate() / 1e18)
     collateral, _, _, trade_fee \
-        = calculate_position_info(oi_initial, leverage, trading_fee_rate)
+        = calculate_position_info(notional_initial, leverage, trading_fee_rate)
 
     # input values for build
     input_collateral = int(collateral * Decimal(1e18))
@@ -180,15 +197,16 @@ def test_build_updates_market(market, ovl, alice):
 
 
 @given(
-    oi=strategy('decimal', min_value='0.001', max_value='800000', places=3),
+    notional=strategy('decimal', min_value='0.001', max_value='80000',
+                      places=3),
     leverage=strategy('decimal', min_value='1.0', max_value='5.0', places=3),
     is_long=strategy('bool'))
-def test_build_registers_volume(market, feed, ovl, alice, oi, leverage,
+def test_build_registers_volume(market, feed, ovl, alice, notional, leverage,
                                 is_long):
     # calculate expected pos info data
     trading_fee_rate = Decimal(market.tradingFeeRate() / 1e18)
-    collateral, oi, debt, trade_fee \
-        = calculate_position_info(oi, leverage, trading_fee_rate)
+    collateral, notional, debt, trade_fee \
+        = calculate_position_info(notional, leverage, trading_fee_rate)
 
     # input values for the tx
     input_collateral = int(collateral * Decimal(1e18))
@@ -220,7 +238,13 @@ def test_build_registers_volume(market, feed, ovl, alice, oi, leverage,
     # NOTE: decayOverWindow() tested in test_rollers.py
     data = feed.latest()
     _, micro_window, _, _, _, _, _, _ = data
-    cap_oi = Decimal(market.capOiAdjustedForBounds(data, market.capOi())/1e18)
+    mid = Decimal(mid_from_feed(data)) / Decimal(1e18)
+
+    oi = notional / mid
+    cap_notional = Decimal(
+        market.capNotionalAdjustedForBounds(data, market.capNotional())/1e18)
+    cap_oi = cap_notional / mid
+
     input_volume = int((oi / cap_oi) * Decimal(1e18))
     input_window = micro_window
     input_timestamp = chain[tx.block_number]['timestamp']
@@ -245,22 +269,22 @@ def test_build_registers_volume(market, feed, ovl, alice, oi, leverage,
         market.snapshotVolumeBid()
 
     actual_timestamp, actual_window, actual_volume = actual
-
     assert actual_timestamp == expect_timestamp
     assert int(actual_window) == approx(expect_window, abs=1)  # tol to 1s
     assert int(actual_volume) == approx(expect_volume)
 
 
 @given(
-    oi=strategy('decimal', min_value='0.001', max_value='800000', places=3),
+    notional=strategy('decimal', min_value='0.001', max_value='80000',
+                      places=3),
     leverage=strategy('decimal', min_value='1.0', max_value='5.0', places=3),
     is_long=strategy('bool'))
-def test_build_executes_transfers(market, factory, ovl, alice, oi, leverage,
-                                  is_long):
+def test_build_executes_transfers(market, factory, ovl, alice, notional,
+                                  leverage, is_long):
     # calculate expected pos info data
     trading_fee_rate = Decimal(market.tradingFeeRate() / 1e18)
-    collateral, oi, debt, trade_fee \
-        = calculate_position_info(oi, leverage, trading_fee_rate)
+    collateral, notional, debt, trade_fee \
+        = calculate_position_info(notional, leverage, trading_fee_rate)
 
     # input values for the tx
     input_collateral = int(collateral * Decimal(1e18))
@@ -302,15 +326,16 @@ def test_build_executes_transfers(market, factory, ovl, alice, oi, leverage,
 
 
 @given(
-    oi=strategy('decimal', min_value='0.001', max_value='800000', places=3),
+    notional=strategy('decimal', min_value='0.001', max_value='80000',
+                      places=3),
     leverage=strategy('decimal', min_value='1.0', max_value='5.0', places=3),
     is_long=strategy('bool'))
-def test_build_transfers_collateral_to_market(market, ovl, alice, oi,
+def test_build_transfers_collateral_to_market(market, ovl, alice, notional,
                                               leverage, is_long):
     # calculate expected pos info data
     trading_fee_rate = Decimal(market.tradingFeeRate() / 1e18)
-    collateral, oi, debt, trade_fee \
-        = calculate_position_info(oi, leverage, trading_fee_rate)
+    collateral, notional, debt, trade_fee \
+        = calculate_position_info(notional, leverage, trading_fee_rate)
 
     # input values for the tx
     input_collateral = int(collateral * Decimal(1e18))
@@ -347,15 +372,16 @@ def test_build_transfers_collateral_to_market(market, ovl, alice, oi,
 
 
 @given(
-    oi=strategy('decimal', min_value='0.001', max_value='800000', places=3),
+    notional=strategy('decimal', min_value='0.001', max_value='80000',
+                      places=3),
     leverage=strategy('decimal', min_value='1.0', max_value='5.0', places=3),
     is_long=strategy('bool'))
-def test_build_transfers_trading_fees(market, factory, ovl, alice, oi,
+def test_build_transfers_trading_fees(market, factory, ovl, alice, notional,
                                       leverage, is_long):
     # calculate expected pos info data
     trading_fee_rate = Decimal(market.tradingFeeRate() / 1e18)
-    collateral, oi, debt, trade_fee \
-        = calculate_position_info(oi, leverage, trading_fee_rate)
+    collateral, notional, debt, trade_fee \
+        = calculate_position_info(notional, leverage, trading_fee_rate)
 
     # input values for the tx
     input_collateral = int(collateral * Decimal(1e18))
@@ -446,8 +472,6 @@ def test_build_reverts_when_leverage_greater_than_cap(market, ovl, alice):
 
     assert expect_pos_id == actual_pos_id
 
-# TODO: def test_build_reverts_when_slippage_greater_than_max:
-
 
 @given(
     leverage=strategy('decimal', min_value='1.0', max_value='5.0', places=3),
@@ -484,7 +508,6 @@ def test_build_reverts_when_collateral_less_than_min(market, ovl, alice,
     assert expect_pos_id == actual_pos_id
 
 
-# TODO: fix this for cap adjustments
 @given(is_long=strategy('bool'))
 def test_build_reverts_when_oi_greater_than_cap(market, ovl, alice, is_long):
     # get position key/id related info
@@ -493,6 +516,8 @@ def test_build_reverts_when_oi_greater_than_cap(market, ovl, alice, is_long):
     input_leverage = int(1e18)
     input_is_long = is_long
 
+    tol = 1e-4
+
     # NOTE: slippage tests in test_slippage.py
     # NOTE: setting to min/max here, so never reverts with slippage>max
     input_price_limit = 2**256-1 if is_long else 0
@@ -500,14 +525,14 @@ def test_build_reverts_when_oi_greater_than_cap(market, ovl, alice, is_long):
     # approve market for spending before build. use max
     ovl.approve(market, 2**256 - 1, {"from": alice})
 
-    # check build reverts when oi is greater than static cap
-    input_collateral = market.capOi() + 1
+    # check build reverts when notional is greater than static cap
+    input_collateral = market.capNotional() * (1 + tol)
     with reverts("OVLV1:oi>cap"):
         _ = market.build(input_collateral, input_leverage, input_is_long,
                          input_price_limit, {"from": alice})
 
-    # check build succeeds when oi is equal to cap
-    input_collateral = market.capOi()
+    # check build succeeds when notional is less than static cap
+    input_collateral = market.capNotional() * (1 - tol)
     _ = market.build(input_collateral, input_leverage, input_is_long,
                      input_price_limit, {"from": alice})
 
@@ -518,18 +543,18 @@ def test_build_reverts_when_oi_greater_than_cap(market, ovl, alice, is_long):
 
 
 def test_multiple_build_creates_multiple_positions(market, factory, ovl,
-                                                   alice, bob):
+                                                   feed, alice, bob):
     # loop through 10 times
     n = 10
-    total_oi_long = Decimal(10000)
-    total_oi_short = Decimal(7500)
+    total_notional_long = Decimal(10000)
+    total_notional_short = Decimal(7500)
 
     # set k to zero to avoid funding calcs
     market.setK(0, {"from": factory})
 
     # alice goes long and bob goes short n times
-    input_total_oi_long = total_oi_long * Decimal(1e18)
-    input_total_oi_short = total_oi_short * Decimal(1e18)
+    input_total_notional_long = total_notional_long * Decimal(1e18)
+    input_total_notional_short = total_notional_short * Decimal(1e18)
 
     # get position key/id related info
     expect_pos_id = market.nextPositionId()
@@ -539,18 +564,18 @@ def test_multiple_build_creates_multiple_positions(market, factory, ovl,
     leverage_cap = Decimal(market.capLeverage() / 1e18)
 
     # approve collateral amount: collateral + trade fee
-    approve_collateral_alice = int((input_total_oi_long *
+    approve_collateral_alice = int((input_total_notional_long *
                                     (1 + trading_fee_rate)))
-    approve_collateral_bob = int((input_total_oi_short *
+    approve_collateral_bob = int((input_total_notional_short *
                                   (1 + trading_fee_rate)))
 
     # approve market for spending then build
     ovl.approve(market, approve_collateral_alice, {"from": alice})
     ovl.approve(market, approve_collateral_bob, {"from": bob})
 
-    # per trade oi values
-    oi_alice = total_oi_long / Decimal(n)
-    oi_bob = total_oi_short / Decimal(n)
+    # per trade notional values
+    notional_alice = total_notional_long / Decimal(n)
+    notional_bob = total_notional_short / Decimal(n)
     is_long_alice = True
     is_long_bob = False
 
@@ -563,9 +588,9 @@ def test_multiple_build_creates_multiple_positions(market, factory, ovl,
 
         # calculate collateral amounts
         collateral_alice, _, debt_alice, _ = calculate_position_info(
-            oi_alice, leverage_alice, trading_fee_rate)
+            notional_alice, leverage_alice, trading_fee_rate)
         collateral_bob, _, debt_bob, _ = calculate_position_info(
-            oi_bob, leverage_bob, trading_fee_rate)
+            notional_bob, leverage_bob, trading_fee_rate)
 
         input_collateral_alice = int(collateral_alice * Decimal(1e18))
         input_collateral_bob = int(collateral_bob * Decimal(1e18))
@@ -576,6 +601,10 @@ def test_multiple_build_creates_multiple_positions(market, factory, ovl,
         # NOTE: setting to min/max here, so never reverts with slippage>max
         input_price_limit_alice = 2**256-1 if is_long_alice else 0
         input_price_limit_bob = 2**256-1 if is_long_bob else 0
+
+        # cache price, liquidity data from feed
+        data = feed.latest()
+        mid_price = mid_from_feed(data)
 
         # cache current aggregate long oi for comparison later
         expect_oi_long = market.oiLong()
@@ -592,30 +621,37 @@ def test_multiple_build_creates_multiple_positions(market, factory, ovl,
 
         # check position info for alice for everything
         # except price to avoid impact calcs
-        expect_oi_alice = int(oi_alice * Decimal(1e18))
+        expect_notional_alice = int(notional_alice * Decimal(1e18))
+        expect_oi_alice = int(Decimal(expect_notional_alice) * Decimal(1e18)
+                              / Decimal(mid_price))
         expect_debt_alice = int(debt_alice * Decimal(1e18))
         expect_is_long_alice = is_long_alice
         expect_liquidated_alice = False
 
         actual_pos_alice = market.positions(
             get_position_key(alice.address, expect_pos_id_alice))
-        (actual_oi_alice, actual_debt_alice, actual_is_long_alice,
-         actual_liquidated_alice, _, _) = actual_pos_alice
+        (actual_notional_alice, actual_debt_alice, actual_is_long_alice,
+         actual_liquidated_alice, _, actual_oi_alice) = actual_pos_alice
 
         assert actual_is_long_alice == expect_is_long_alice
         assert actual_liquidated_alice == expect_liquidated_alice
-        assert int(actual_oi_alice) == approx(expect_oi_alice)
+        assert int(actual_notional_alice) == approx(expect_notional_alice)
+        assert int(actual_oi_alice) == approx(expect_oi_alice, rel=1e-4)
         assert int(actual_debt_alice) == approx(expect_debt_alice)
 
         # check oi added to long side by alice
         expect_oi_long += expect_oi_alice
         actual_oi_long = market.oiLong()
 
-        assert int(actual_oi_long) == approx(expect_oi_long)
+        assert int(actual_oi_long) == approx(expect_oi_long, rel=1e-4)
 
         # check next position id incremented
         assert market.nextPositionId() == expect_pos_id + 1
         expect_pos_id += 1
+
+        # cache price, liquidity data from feed
+        data = feed.latest()
+        mid_price = mid_from_feed(data)
 
         # cache current aggregate short oi for comparison later
         expect_oi_short = market.oiShort()
@@ -631,26 +667,29 @@ def test_multiple_build_creates_multiple_positions(market, factory, ovl,
 
         # check position info for bob for everything
         # except price to avoid impact calcs
-        expect_oi_bob = int(oi_bob * Decimal(1e18))
+        expect_notional_bob = int(notional_bob * Decimal(1e18))
+        expect_oi_bob = int(Decimal(expect_notional_bob) * Decimal(1e18)
+                            / Decimal(mid_price))
         expect_debt_bob = int(debt_bob * Decimal(1e18))
         expect_is_long_bob = is_long_bob
         expect_liquidated_bob = False
 
         actual_pos_bob = market.positions(
             get_position_key(bob.address, expect_pos_id_bob))
-        (actual_oi_bob, actual_debt_bob, actual_is_long_bob,
-         actual_liquidated_bob, _, _) = actual_pos_bob
+        (actual_notional_bob, actual_debt_bob, actual_is_long_bob,
+         actual_liquidated_bob, _, actual_oi_bob) = actual_pos_bob
 
         assert actual_is_long_bob == expect_is_long_bob
         assert actual_liquidated_bob is expect_liquidated_bob
-        assert int(actual_oi_bob) == approx(expect_oi_bob)
+        assert int(actual_notional_bob) == approx(expect_notional_bob)
+        assert int(actual_oi_bob) == approx(expect_oi_bob, rel=1e-4)
         assert int(actual_debt_bob) == approx(expect_debt_bob)
 
         # check oi added to short side by bob
         expect_oi_short += expect_oi_bob
         actual_oi_short = market.oiShort()
 
-        assert int(actual_oi_short) == approx(expect_oi_short)
+        assert int(actual_oi_short) == approx(expect_oi_short, rel=1e-4)
 
         # check next position id incremented
         assert market.nextPositionId() == expect_pos_id + 1

--- a/tests/markets/test_conftest.py
+++ b/tests/markets/test_conftest.py
@@ -43,7 +43,7 @@ def test_mock_market_fixture(mock_market, mock_feed, ovl, factory, gov):
     assert mock_market.lmbda() == 1000000000000000000
     assert mock_market.delta() == 2500000000000000
     assert mock_market.capPayoff() == 5000000000000000000
-    assert mock_market.capOi() == 800000000000000000000000
+    assert mock_market.capNotional() == 800000000000000000000000
     assert mock_market.capLeverage() == 5000000000000000000
     assert mock_market.circuitBreakerWindow() == 2592000
     assert mock_market.circuitBreakerMintTarget() == 66670000000000000000000
@@ -83,7 +83,7 @@ def test_market_fixture(market, feed, ovl, factory, gov):
     assert market.lmbda() == 1000000000000000000
     assert market.delta() == 2500000000000000
     assert market.capPayoff() == 5000000000000000000
-    assert market.capOi() == 800000000000000000000000
+    assert market.capNotional() == 800000000000000000000000
     assert market.capLeverage() == 5000000000000000000
     assert market.circuitBreakerWindow() == 2592000
     assert market.circuitBreakerMintTarget() == 66670000000000000000000

--- a/tests/markets/test_conftest.py
+++ b/tests/markets/test_conftest.py
@@ -40,7 +40,7 @@ def test_mock_market_fixture(mock_market, mock_feed, ovl, factory, gov):
 
     # risk params
     assert mock_market.k() == 1220000000000
-    assert mock_market.lmbda() == 1000000000000000000
+    assert mock_market.lmbda() == 500000000000000000
     assert mock_market.delta() == 2500000000000000
     assert mock_market.capPayoff() == 5000000000000000000
     assert mock_market.capNotional() == 800000000000000000000000
@@ -80,7 +80,7 @@ def test_market_fixture(market, feed, ovl, factory, gov):
 
     # risk params
     assert market.k() == 1220000000000
-    assert market.lmbda() == 1000000000000000000
+    assert market.lmbda() == 500000000000000000
     assert market.delta() == 2500000000000000
     assert market.capPayoff() == 5000000000000000000
     assert market.capNotional() == 800000000000000000000000

--- a/tests/markets/test_deploy.py
+++ b/tests/markets/test_deploy.py
@@ -14,7 +14,7 @@ def test_deploy_creates_market(ovl, feed, factory, gov):
     lmbda = 1000000000000000000
     delta = 2500000000000000
     cap_payoff = 5000000000000000000
-    cap_oi = 800000000000000000000000
+    cap_notional = 800000000000000000000000
     cap_leverage = 5000000000000000000
     circuit_breaker_window = 2592000
     circuit_breaker_mint_target = 66670000000000000000000
@@ -25,7 +25,7 @@ def test_deploy_creates_market(ovl, feed, factory, gov):
     min_collateral = 100000000000000
     price_drift_upper_limit = 100000000000000
 
-    params = (k, lmbda, delta, cap_payoff, cap_oi, cap_leverage,
+    params = (k, lmbda, delta, cap_payoff, cap_notional, cap_leverage,
               circuit_breaker_window, circuit_breaker_mint_target,
               maintenance_margin_fraction, maintenance_margin_burn_rate,
               liquidation_fee_rate, trading_fee_rate, min_collateral,
@@ -44,7 +44,7 @@ def test_deploy_creates_market(ovl, feed, factory, gov):
     assert market.lmbda() == lmbda
     assert market.delta() == delta
     assert market.capPayoff() == cap_payoff
-    assert market.capOi() == cap_oi
+    assert market.capNotional() == cap_notional
     assert market.capLeverage() == cap_leverage
     assert market.circuitBreakerWindow() == circuit_breaker_window
     assert market.circuitBreakerMintTarget() == circuit_breaker_mint_target
@@ -62,7 +62,7 @@ def test_deploy_reverts_when_price_is_zero(ovl, mock_feed, factory, gov):
     lmbda = 1000000000000000000
     delta = 2500000000000000
     cap_payoff = 5000000000000000000
-    cap_oi = 800000000000000000000000
+    cap_notional = 800000000000000000000000
     cap_leverage = 5000000000000000000
     circuit_breaker_window = 2592000
     circuit_breaker_mint_target = 66670000000000000000000
@@ -73,7 +73,7 @@ def test_deploy_reverts_when_price_is_zero(ovl, mock_feed, factory, gov):
     min_collateral = 100000000000000
     price_drift_upper_limit = 100000000000000
 
-    params = (k, lmbda, delta, cap_payoff, cap_oi, cap_leverage,
+    params = (k, lmbda, delta, cap_payoff, cap_notional, cap_leverage,
               circuit_breaker_window, circuit_breaker_mint_target,
               maintenance_margin_fraction, maintenance_margin_burn_rate,
               liquidation_fee_rate, trading_fee_rate, min_collateral,
@@ -95,7 +95,7 @@ def test_deploy_reverts_when_max_leverage_is_liquidatable(ovl, mock_feed,
     lmbda = 1000000000000000000
     delta = 2500000000000000
     cap_payoff = 5000000000000000000
-    cap_oi = 800000000000000000000000
+    cap_notional = 800000000000000000000000
     cap_leverage = 5000000000000000000
     circuit_breaker_window = 2592000
     circuit_breaker_mint_target = 66670000000000000000000
@@ -106,7 +106,7 @@ def test_deploy_reverts_when_max_leverage_is_liquidatable(ovl, mock_feed,
     min_collateral = 100000000000000
     price_drift_upper_limit = 100000000000000
 
-    params = (k, lmbda, delta, cap_payoff, cap_oi, cap_leverage,
+    params = (k, lmbda, delta, cap_payoff, cap_notional, cap_leverage,
               circuit_breaker_window, circuit_breaker_mint_target,
               maintenance_margin_fraction, maintenance_margin_burn_rate,
               liquidation_fee_rate, trading_fee_rate, min_collateral,
@@ -124,7 +124,7 @@ def test_deploy_reverts_when_price_drift_exceeds_max_exp(ovl, mock_feed,
     lmbda = 1000000000000000000
     delta = 2500000000000000
     cap_payoff = 5000000000000000000
-    cap_oi = 800000000000000000000000
+    cap_notional = 800000000000000000000000
     cap_leverage = 5000000000000000000
     circuit_breaker_window = 2592000
     circuit_breaker_mint_target = 66670000000000000000000
@@ -135,7 +135,7 @@ def test_deploy_reverts_when_price_drift_exceeds_max_exp(ovl, mock_feed,
     min_collateral = 100000000000000
     price_drift_upper_limit = 100000000000000000
 
-    params = (k, lmbda, delta, cap_payoff, cap_oi, cap_leverage,
+    params = (k, lmbda, delta, cap_payoff, cap_notional, cap_leverage,
               circuit_breaker_window, circuit_breaker_mint_target,
               maintenance_margin_fraction, maintenance_margin_burn_rate,
               liquidation_fee_rate, trading_fee_rate, min_collateral,

--- a/tests/markets/test_funding.py
+++ b/tests/markets/test_funding.py
@@ -1,6 +1,7 @@
 from pytest import approx
 from brownie.test import given, strategy
 from decimal import Decimal
+from math import exp, sqrt
 
 
 @given(
@@ -8,21 +9,24 @@ from decimal import Decimal
                      places=3),
     oi_short=strategy('decimal', min_value='0.001', max_value='800000',
                       places=3),
-    dt=strategy('uint256', min_value='0', max_value='7776000'))
+    dt=strategy('uint256', min_value='0', max_value='2592000'))
 def test_oi_after_funding(market, oi_long, oi_short, dt):
     oi_long = oi_long * Decimal(1e18)
     oi_short = oi_short * Decimal(1e18)
     oi_overweight = oi_long if oi_long >= oi_short else oi_short
     oi_underweight = oi_short if oi_long >= oi_short else oi_long
 
-    oi = oi_long + oi_short
-    oi_imb = oi_long - oi_short if oi_long >= oi_short else oi_short - oi_long
+    oi = oi_overweight + oi_underweight
+    oi_imb = oi_overweight - oi_underweight
 
     # calculate expected oi values long and short
-    k = market.k() / Decimal(1e18)
-    oi_imb *= (1 - 2*k) ** (dt)
-    expect_oi_overweight = int((oi + oi_imb) / 2)
-    expect_oi_underweight = int((oi - oi_imb) / 2)
+    k = Decimal(market.k()) / Decimal(1e18)
+    expect_oi = oi * Decimal(
+        sqrt(1 - (oi_imb/oi)**2 * Decimal(1 - exp(-4*k*dt))))
+    expect_oi_imb = oi_imb * Decimal(exp(-2*k*dt))
+
+    expect_oi_overweight = int((expect_oi + expect_oi_imb) / 2)
+    expect_oi_underweight = int((expect_oi - expect_oi_imb) / 2)
 
     # get actual oi values long and short
     actual_oi_overweight, actual_oi_underweight = market.oiAfterFunding(
@@ -36,18 +40,19 @@ def test_oi_after_funding(market, oi_long, oi_short, dt):
 @given(
     oi_overweight=strategy('decimal', min_value='0.001', max_value='800000',
                            places=3),
-    dt=strategy('uint256', min_value='0', max_value='7776000'))
+    dt=strategy('uint256', min_value='0', max_value='2592000'))
 def test_oi_after_funding_when_underweight_is_zero(market, oi_overweight, dt):
     oi_overweight = oi_overweight * Decimal(1e18)
     oi_underweight = 0
+
     oi_imb = oi_overweight
 
     # calculate expected oi values long and short
-    k = market.k() / Decimal(1e18)
-    oi_imb *= (1 - 2*k) ** (dt)
+    k = Decimal(market.k()) / Decimal(1e18)
+    expect_oi_imb = oi_imb * Decimal(exp(-2*k*dt))
 
     # overweight gets drawn down
-    expect_oi_overweight = int(oi_imb)
+    expect_oi_overweight = int(expect_oi_imb)
     expect_oi_underweight = 0
 
     # get actual oi values long and short
@@ -67,5 +72,79 @@ def test_oi_after_funding_when_longs_and_shorts_are_zero(market):
     actual_oi_overweight, actual_oi_underweight = market.oiAfterFunding(
         oi_long, oi_short, dt)
 
+    # should remain zero
     assert actual_oi_overweight == 0
     assert actual_oi_underweight == 0
+
+
+@given(
+    oi_long=strategy('decimal', min_value='0.001', max_value='800000',
+                     places=3),
+    oi_short=strategy('decimal', min_value='0.001', max_value='800000',
+                      places=3))
+def test_oi_after_funding_when_dt_infinite(market, oi_long, oi_short):
+    # let time go to "infinity"
+    oi_long = oi_long * Decimal(1e18)
+    oi_short = oi_short * Decimal(1e18)
+    oi_overweight = oi_long if oi_long >= oi_short else oi_short
+    oi_underweight = oi_short if oi_long >= oi_short else oi_long
+
+    oi = oi_overweight + oi_underweight
+    oi_imb = oi_overweight - oi_underweight
+
+    tol = 1e-4
+
+    # calculate time elapsed needed to get a MAX_NATURAL_EXPONENT in
+    # imb drawdown power
+    max_exponent = Decimal(20)
+    k = Decimal(market.k()) / Decimal(1e18)
+    dt = (max_exponent / (2 * k)) * Decimal(1 + tol)
+
+    # calculate expected oi values long and short
+    expect_oi = Decimal(sqrt(oi**2 - oi_imb**2))
+    expect_oi_imb = 0
+
+    expect_oi_overweight = int((expect_oi + expect_oi_imb) / 2)
+    expect_oi_underweight = int((expect_oi - expect_oi_imb) / 2)
+
+    # check actual equals expected
+    actual_oi_overweight, actual_oi_underweight = market.oiAfterFunding(
+        oi_overweight, oi_underweight, dt)
+
+    assert int(actual_oi_overweight) == approx(expect_oi_overweight)
+    assert int(actual_oi_underweight) == approx(expect_oi_underweight)
+
+    # check no reverts if before "infinite" time elapsed power
+    dt = (max_exponent / (2 * k)) * Decimal(1 - tol)
+    _, _ = market.oiAfterFunding(oi_overweight, oi_underweight, dt)
+
+
+def test_oi_after_funding_when_underweight_is_zero_dt_infinite(market):
+    # all oi should be to overweight side and let time go to "infinity"
+    # to test edge case of oiOverWeightNow => 0
+    oi_overweight = Decimal(10 * 1e18)
+    oi_underweight = 0
+
+    tol = 1e-4
+
+    # calculate time elapsed needed to get a MAX_NATURAL_EXPONENT in
+    # imb drawdown power
+    max_exponent = Decimal(20)
+    k = Decimal(market.k()) / Decimal(1e18)
+    dt = (max_exponent / (2 * k)) * Decimal(1 + tol)
+
+    # overweight gets drawn down to zero if beyond "infinite" time elasped
+    # alongside underweight (i.e. all contracts burned)
+    actual_oi_overweight, actual_oi_underweight = market.oiAfterFunding(
+        oi_overweight, oi_underweight, dt)
+
+    assert actual_oi_overweight == 0
+    assert actual_oi_underweight == 0
+
+    # check overweight != 0 if before "infinite" time elapsed power
+    dt = (max_exponent / (2 * k)) * Decimal(1 - tol)
+    actual_oi_overweight, actual_oi_underweight = market.oiAfterFunding(
+        oi_overweight, oi_underweight, dt)
+
+    assert actual_oi_underweight == 0
+    assert actual_oi_overweight > 0

--- a/tests/markets/test_liquidate.py
+++ b/tests/markets/test_liquidate.py
@@ -51,8 +51,8 @@ def test_liquidate_updates_position(mock_market, mock_feed, alice, rando,
 
     # get position info
     pos_key = get_position_key(alice.address, pos_id)
-    (expect_oi_shares, expect_debt, expect_is_long, expect_liquidated,
-     expect_entry_price) = mock_market.positions(pos_key)
+    (_, expect_debt, expect_is_long, expect_liquidated,
+     expect_entry_price, expect_oi_shares) = mock_market.positions(pos_key)
 
     # mine the chain forward for some time difference with build and liquidate
     # funding should occur within this interval.
@@ -128,8 +128,8 @@ def test_liquidate_updates_position(mock_market, mock_feed, alice, rando,
     expect_liquidated = True
 
     # check expected pos attributes match actual after liquidate
-    (actual_oi_shares, actual_debt, actual_is_long, actual_liquidated,
-     actual_entry_price) = mock_market.positions(pos_key)
+    (_, actual_debt, actual_is_long, actual_liquidated,
+     actual_entry_price, actual_oi_shares) = mock_market.positions(pos_key)
 
     assert actual_oi_shares == expect_oi_shares
     assert actual_debt == expect_debt
@@ -204,8 +204,8 @@ def test_liquidate_removes_oi(mock_market, mock_feed, alice, rando, ovl,
 
     # get position info
     pos_key = get_position_key(alice.address, pos_id)
-    (expect_oi_shares, expect_debt, expect_is_long, expect_liquidated,
-     expect_entry_price) = mock_market.positions(pos_key)
+    (_, expect_debt, expect_is_long, expect_liquidated,
+     expect_entry_price, expect_oi_shares) = mock_market.positions(pos_key)
 
     # mine the chain forward for some time difference with build and liquidate
     # funding should occur within this interval.
@@ -315,8 +315,8 @@ def test_liquidate_updates_market(mock_market, mock_feed, alice, rando, ovl):
 
     # get position info
     pos_key = get_position_key(alice.address, pos_id)
-    (expect_oi_shares, expect_debt, expect_is_long, expect_liquidated,
-     expect_entry_price) = mock_market.positions(pos_key)
+    (_, expect_debt, expect_is_long, expect_liquidated,
+     expect_entry_price, expect_oi_shares) = mock_market.positions(pos_key)
 
     # cache prior timestamp update last value
     prior_timestamp_update_last = mock_market.timestampUpdateLast()
@@ -421,8 +421,8 @@ def test_liquidate_registers_zero_volume(mock_market, mock_feed, alice, rando,
 
     # get position info
     pos_key = get_position_key(alice.address, pos_id)
-    (expect_oi_shares, expect_debt, expect_is_long, expect_liquidated,
-     expect_entry_price) = mock_market.positions(pos_key)
+    (_, expect_debt, expect_is_long, expect_liquidated,
+     expect_entry_price, expect_oi_shares) = mock_market.positions(pos_key)
 
     # mine the chain forward for some time difference with build and liquidate
     # funding should occur within this interval.
@@ -540,8 +540,8 @@ def test_liquidate_registers_mint(mock_market, mock_feed, alice, rando, ovl,
 
     # get position info
     pos_key = get_position_key(alice.address, pos_id)
-    (expect_oi_shares, expect_debt, expect_is_long, expect_liquidated,
-     expect_entry_price) = mock_market.positions(pos_key)
+    (_, expect_debt, expect_is_long, expect_liquidated,
+     expect_entry_price, expect_oi_shares) = mock_market.positions(pos_key)
 
     # mine the chain forward for some time difference with build and liquidate
     # funding should occur within this interval.
@@ -676,8 +676,8 @@ def test_liquidate_executes_transfers(mock_market, mock_feed, alice, rando,
 
     # get position info
     pos_key = get_position_key(alice.address, pos_id)
-    (expect_oi_shares, expect_debt, expect_is_long, expect_liquidated,
-     expect_entry_price) = mock_market.positions(pos_key)
+    (_, expect_debt, expect_is_long, expect_liquidated,
+     expect_entry_price, expect_oi_shares) = mock_market.positions(pos_key)
 
     # mine the chain forward for some time difference with build and liquidate
     # funding should occur within this interval.
@@ -839,8 +839,8 @@ def test_liquidate_transfers_value_to_liquidator(mock_market, mock_feed, alice,
 
     # get position info
     pos_key = get_position_key(alice.address, pos_id)
-    (expect_oi_shares, expect_debt, expect_is_long, expect_liquidated,
-     expect_entry_price) = mock_market.positions(pos_key)
+    (_, expect_debt, expect_is_long, expect_liquidated,
+     expect_entry_price, expect_oi_shares) = mock_market.positions(pos_key)
 
     # mine the chain forward for some time difference with build and liquidate
     # funding should occur within this interval.
@@ -965,8 +965,8 @@ def test_liquidate_transfers_liquidation_fees(mock_market, mock_feed, alice,
 
     # get position info
     pos_key = get_position_key(alice.address, pos_id)
-    (expect_oi_shares, expect_debt, expect_is_long, expect_liquidated,
-     expect_entry_price) = mock_market.positions(pos_key)
+    (_, expect_debt, expect_is_long, expect_liquidated,
+     expect_entry_price, expect_oi_shares) = mock_market.positions(pos_key)
 
     # mine the chain forward for some time difference with build and liquidate
     # funding should occur within this interval.
@@ -1096,8 +1096,8 @@ def test_liquidate_floors_value_to_zero_when_position_underwater(mock_market,
 
     # get position info
     pos_key = get_position_key(alice.address, pos_id)
-    (expect_oi_shares, expect_debt, expect_is_long, expect_liquidated,
-     expect_entry_price) = mock_market.positions(pos_key)
+    (_, expect_debt, expect_is_long, expect_liquidated,
+     expect_entry_price, expect_oi_shares) = mock_market.positions(pos_key)
 
     # mine the chain forward for some time difference with build and liquidate
     # funding should occur within this interval.
@@ -1209,8 +1209,8 @@ def test_liquidate_reverts_when_not_position_owner(mock_market, mock_feed,
 
     # get position info
     pos_key = get_position_key(alice.address, pos_id)
-    (expect_oi_shares, expect_debt, expect_is_long, expect_liquidated,
-     expect_entry_price) = mock_market.positions(pos_key)
+    (_, expect_debt, expect_is_long, expect_liquidated,
+     expect_entry_price, expect_oi_shares) = mock_market.positions(pos_key)
 
     # mine the chain forward for some time difference with build and liquidate
     # funding should occur within this interval.
@@ -1319,8 +1319,8 @@ def test_liquidate_reverts_when_position_liquidated(mock_market, mock_feed,
 
     # get position info
     pos_key = get_position_key(alice.address, pos_id)
-    (expect_oi_shares, expect_debt, expect_is_long, expect_liquidated,
-     expect_entry_price) = mock_market.positions(pos_key)
+    (_, expect_debt, expect_is_long, expect_liquidated,
+     expect_entry_price, expect_oi_shares) = mock_market.positions(pos_key)
 
     # mine the chain forward for some time difference with build and liquidate
     # funding should occur within this interval.
@@ -1419,8 +1419,8 @@ def test_liquidate_reverts_when_position_not_liquidatable(mock_market,
 
     # get position info
     pos_key = get_position_key(alice.address, pos_id)
-    (expect_oi_shares, expect_debt, expect_is_long, expect_liquidated,
-     expect_entry_price) = mock_market.positions(pos_key)
+    (_, expect_debt, expect_is_long, expect_liquidated,
+     expect_entry_price, expect_oi_shares) = mock_market.positions(pos_key)
 
     # mine the chain forward for some time difference with build and liquidate
     # funding should occur within this interval.
@@ -1500,5 +1500,5 @@ def test_liquidate_reverts_when_position_not_liquidatable(mock_market,
     mock_market.liquidate(input_owner, input_pos_id, {"from": rando})
 
     # check position has been liquidated
-    (_, _, _, actual_liquidated, _) = mock_market.positions(pos_key)
+    (_, _, _, actual_liquidated, _, _) = mock_market.positions(pos_key)
     assert actual_liquidated is True

--- a/tests/markets/test_liquidate.py
+++ b/tests/markets/test_liquidate.py
@@ -3,7 +3,6 @@ from pytest import approx
 from brownie import chain, reverts
 from brownie.test import given, strategy
 from decimal import Decimal
-from math import exp
 
 from .utils import calculate_position_info, get_position_key, mid_from_feed
 

--- a/tests/markets/test_oi_cap.py
+++ b/tests/markets/test_oi_cap.py
@@ -138,7 +138,7 @@ def test_cap_notional_adjusted_for_circuit_breaker(market, feed):
     assert actual == expect
 
 
-def test_cap_oi(market, feed):
+def test_oi_from_notional(market, feed):
     cap_notional = market.capNotional()
     data = feed.latest()
 
@@ -148,5 +148,5 @@ def test_cap_oi(market, feed):
     cap_oi = Decimal(cap_notional) / Decimal(mid)
 
     expect = int(cap_oi * Decimal(1e18))
-    actual = market.capOi(data, cap_notional)
+    actual = market.oiFromNotional(data, cap_notional)
     assert int(actual) == approx(expect)

--- a/tests/markets/test_oi_cap.py
+++ b/tests/markets/test_oi_cap.py
@@ -2,6 +2,8 @@ from decimal import Decimal
 from pytest import approx
 from brownie.test import given, strategy
 
+from .utils import mid_from_feed
+
 
 def test_cap_notional_front_run_bound(market, feed):
     lmbda = Decimal(market.lmbda()) / Decimal(1e18)
@@ -144,7 +146,7 @@ def test_oi_from_notional(market, feed):
 
     # oi cap should be cap notional / mid, with zero volume assumption on
     # mid so cap is dependent on only underlying feed price
-    mid = market.mid(data, 0, 0)
+    mid = mid_from_feed(data)
     cap_oi = Decimal(cap_notional) / Decimal(mid)
 
     expect = int(cap_oi * Decimal(1e18))

--- a/tests/markets/test_oi_cap.py
+++ b/tests/markets/test_oi_cap.py
@@ -3,7 +3,7 @@ from pytest import approx
 from brownie.test import given, strategy
 
 
-def test_cap_oi_front_run_bound(market, feed):
+def test_cap_notional_front_run_bound(market, feed):
     lmbda = Decimal(market.lmbda()) / Decimal(1e18)
     data = feed.latest()
 
@@ -11,13 +11,13 @@ def test_cap_oi_front_run_bound(market, feed):
     # TODO: generalize for any feed
     _, _, _, _, _, _, reserve_micro, _ = data
 
-    # check front run bound is lmbda * reserveOverMicro / 2 when has reserve
-    expect = int(lmbda * Decimal(reserve_micro) / Decimal(2))
+    # check front run bound is lmbda * reserveOverMicro when has reserve
+    expect = int(lmbda * Decimal(reserve_micro))
     actual = market.frontRunBound(data)
     assert int(actual) == approx(expect)
 
 
-def test_cap_oi_back_run_bound(market, feed):
+def test_cap_notional_back_run_bound(market, feed):
     delta = Decimal(market.delta()) / Decimal(1e18)
     data = feed.latest()
 
@@ -33,32 +33,33 @@ def test_cap_oi_back_run_bound(market, feed):
     assert int(actual) == approx(expect)
 
 
-def test_cap_oi_adjusted_for_bounds(market, feed):
-    # Test cap oi adjustments is min of all bounds and circuit breaker
-    cap_oi = market.capOi()
+def test_cap_notional_adjusted_for_bounds(market, feed):
+    # Test cap notional adjustments is min of all bounds and circuit breaker
+    cap_notional = market.capNotional()
     data = feed.latest()
 
-    # calculate cap oi bounds:
+    # calculate cap notional bounds:
     # 1. front run bound; 2. back run bound
-    cap_oi_front_run_bound = market.frontRunBound(data)
-    cap_oi_back_run_bound = market.backRunBound(data)
+    cap_notional_front_run_bound = market.frontRunBound(data)
+    cap_notional_back_run_bound = market.backRunBound(data)
 
     # expect is the min of all cap quantities
-    expect = min(cap_oi, cap_oi_front_run_bound, cap_oi_back_run_bound)
-    actual = market.capOiAdjustedForBounds(data, cap_oi)
+    expect = min(cap_notional, cap_notional_front_run_bound,
+                 cap_notional_back_run_bound)
+    actual = market.capNotionalAdjustedForBounds(data, cap_notional)
     assert actual == expect
 
 
-def test_cap_oi_adjusted_for_bounds_when_no_reserve(market, feed):
-    # Test cap oi adjustments is min of all bounds and circuit breaker
-    cap_oi = market.capOi()
+def test_cap_notional_adjusted_for_bounds_when_no_reserve(market, feed):
+    # Test cap notional adjustments is min of all bounds and circuit breaker
+    cap_notional = market.capNotional()
     data = (1642797758, 600, 3600, 2729583770051358617413,
             2739701430255362520176, 2729583770051358617413,
             1909229154186640322863637, False)  # has_reserve = False
 
-    # check cap adjusted for bounds is cap_oi when no reserve
-    expect = cap_oi
-    actual = market.capOiAdjustedForBounds(data, cap_oi)
+    # check cap adjusted for bounds is cap_notional when no reserve
+    expect = cap_notional
+    actual = market.capNotionalAdjustedForBounds(data, cap_notional)
     assert actual == expect
 
 
@@ -66,8 +67,8 @@ def test_cap_oi_adjusted_for_bounds_when_no_reserve(market, feed):
 @given(
     minted=strategy('decimal', min_value='66670', max_value='133340',
                     places=1))
-def test_cap_oi_circuit_breaker(market, minted):
-    cap_oi = market.capOi()
+def test_cap_notional_circuit_breaker(market, minted):
+    cap_notional = market.capNotional()
     target = market.circuitBreakerMintTarget()
 
     # assemble Roller.snapshot struct
@@ -76,9 +77,9 @@ def test_cap_oi_circuit_breaker(market, minted):
     minted = int(minted * Decimal(1e18))
     snapshot = (timestamp, window, minted)
 
-    # check breaker bound returns capOi
-    expect = int(cap_oi * (2 - minted / target))
-    actual = market.circuitBreaker(snapshot, cap_oi)
+    # check breaker bound returns capNotional
+    expect = int(cap_notional * (2 - minted / target))
+    actual = market.circuitBreaker(snapshot, cap_notional)
     assert int(actual) == approx(expect)
 
 
@@ -86,8 +87,9 @@ def test_cap_oi_circuit_breaker(market, minted):
 @given(
     minted=strategy('decimal', min_value='-133340', max_value='66670',
                     places=1))
-def test_cap_oi_circuit_breaker_when_minted_less_than_target(market, minted):
-    cap_oi = market.capOi()
+def test_cap_notional_circuit_breaker_when_minted_less_than_target(market,
+                                                                   minted):
+    cap_notional = market.capNotional()
 
     # assemble Roller.snapshot struct
     timestamp = 1643247197
@@ -95,9 +97,9 @@ def test_cap_oi_circuit_breaker_when_minted_less_than_target(market, minted):
     minted = int(minted * Decimal(1e18))
     snapshot = (timestamp, window, minted)
 
-    # check breaker bound returns capOi
-    expect = cap_oi
-    actual = market.circuitBreaker(snapshot, cap_oi)
+    # check breaker bound returns capNotional
+    expect = cap_notional
+    actual = market.circuitBreaker(snapshot, cap_notional)
     assert actual == expect
 
 
@@ -105,9 +107,9 @@ def test_cap_oi_circuit_breaker_when_minted_less_than_target(market, minted):
 @given(
     minted=strategy('decimal', min_value='133340', max_value='266680',
                     places=1))
-def test_cap_oi_circuit_breaker_when_minted_greater_than_2x_target(market,
-                                                                   minted):
-    cap_oi = market.capOi()
+def test_cap_notional_circuit_breaker_when_mint_greater_than_2x_target(market,
+                                                                       minted):
+    cap_notional = market.capNotional()
 
     # assemble Roller.snapshot struct
     timestamp = 1643247197
@@ -115,21 +117,26 @@ def test_cap_oi_circuit_breaker_when_minted_greater_than_2x_target(market,
     minted = int(minted * Decimal(1e18))
     snapshot = (timestamp, window, minted)
 
-    # check breaker bound returns capOi
+    # check breaker bound returns capNotional
     expect = 0
-    actual = market.circuitBreaker(snapshot, cap_oi)
+    actual = market.circuitBreaker(snapshot, cap_notional)
     assert actual == expect
 
 
-def test_cap_oi_adjusted_for_circuit_breaker(market, feed):
-    # Test cap oi circuit adjustment is min cap oi and circuit breaker
-    cap_oi = market.capOi()
+def test_cap_notional_adjusted_for_circuit_breaker(market, feed):
+    # Test cap notional circuit adjustment is min cap notional and
+    # circuit breaker
+    cap_notional = market.capNotional()
     snapshot = market.snapshotMinted()
 
-    # calculate cap oi adjusted for circuit breaker
-    cap_oi_circuit_breaker = market.circuitBreaker(snapshot, cap_oi)
+    # calculate cap notional adjusted for circuit breaker
+    cap_notional_circuit_breaker = market.circuitBreaker(snapshot,
+                                                         cap_notional)
 
     # expect is the min of all cap quantities
-    expect = min(cap_oi, cap_oi_circuit_breaker)
-    actual = market.capOiAdjustedForCircuitBreaker(cap_oi)
+    expect = min(cap_notional, cap_notional_circuit_breaker)
+    actual = market.capNotionalAdjustedForCircuitBreaker(cap_notional)
     assert actual == expect
+
+
+# TODO: test_cap_oi

--- a/tests/markets/test_price.py
+++ b/tests/markets/test_price.py
@@ -35,7 +35,7 @@ def test_bid_adds_market_impact(market, volume):
     delta = Decimal(market.delta() / 1e18)
     lmbda = Decimal(market.lmbda() / 1e18)
 
-    # use volume anywhere from 0.1% to 100% of the oi cap
+    # use volume anywhere from 0.1% to 100% of the cap
     input_volume = volume * Decimal(1e18)
 
     # bids get the lower of micro/macro prices (worse price), multiplied
@@ -56,7 +56,7 @@ def test_bid_reverts_when_slippage_greater_than_max(market):
 
     # use volume greater than max slippage
     tol = 1e-4  # tolerance put at +/- 1bps
-    max_pow = 41
+    max_pow = 20
     max_volume = (max_pow - delta) / lmbda
 
     # check reverts when volume produces slippage greater than max
@@ -101,7 +101,7 @@ def test_ask_adds_market_impact(market, volume):
     delta = Decimal(market.delta() / 1e18)
     lmbda = Decimal(market.lmbda() / 1e18)
 
-    # use volume anywhere from 0.1% to 100% of the oi cap
+    # use volume anywhere from 0.1% to 100% of the cap
     input_volume = volume * Decimal(1e18)
 
     # asks get the higher of micro/macro prices (worse price), multiplied
@@ -122,7 +122,7 @@ def test_ask_reverts_when_impact_greater_than_max_slippage(market):
 
     # use volume greater than max slippage
     tol = 1e-4  # tolerance put at +/- 1bps
-    max_pow = 41
+    max_pow = 20
     max_volume = (max_pow - delta) / lmbda
 
     # check reverts when volume produces slippage greater than max

--- a/tests/markets/test_setters.py
+++ b/tests/markets/test_setters.py
@@ -59,10 +59,10 @@ def test_set_cap_payoff(market, factory):
     assert expect == actual
 
 
-def test_set_cap_oi(market, factory):
+def test_set_cap_notional(market, factory):
     expect = 900000000000000000000000
-    market.setCapOi(expect, {"from": factory})
-    actual = market.capOi()
+    market.setCapNotional(expect, {"from": factory})
+    actual = market.capNotional()
     assert expect == actual
 
 
@@ -169,7 +169,7 @@ def test_set_min_collateral(market, factory):
 
 
 def test_set_price_drift_upper_limit(market, factory):
-    expect = 500000000000000
+    expect = 50000000000000
     market.setPriceDriftUpperLimit(expect, {"from": factory})
     actual = market.priceDriftUpperLimit()
     assert expect == actual
@@ -179,7 +179,7 @@ def test_set_price_drift_upper_limit_reverts_when_exceeds_max_exp(
     market, feed, factory
 ):
     _, _, macro_window, _, _, _, _, _ = feed.latest()
-    max_exp = 41000000000000000000
+    max_exp = 20000000000000000000
     max_price_drift_upper_limit = int(Decimal(max_exp)/Decimal(macro_window)) \
         + 1
 

--- a/tests/markets/test_setters.py
+++ b/tests/markets/test_setters.py
@@ -196,3 +196,6 @@ def test_set_price_drift_upper_limit_reverts_when_exceeds_max_exp(
     expect = max_price_drift_upper_limit
     actual = market.priceDriftUpperLimit()
     assert expect == actual
+
+
+# TODO: setter revert tests when not factory

--- a/tests/markets/test_slippage.py
+++ b/tests/markets/test_slippage.py
@@ -103,7 +103,7 @@ def test_unwind_when_price_limit_is_breached(market, feed, alice, factory, ovl,
     # get position info
     pos_key = get_position_key(alice.address, pos_id)
     pos = market.positions(pos_key)
-    (actual_notional, _, _, _, actual_entry_price) = pos
+    (actual_notional, _, _, _, actual_entry_price, _) = pos
     oi = Decimal(actual_notional) / Decimal(actual_entry_price)
 
     # calculate expected exit price
@@ -137,7 +137,7 @@ def test_unwind_when_price_limit_is_breached(market, feed, alice, factory, ovl,
     expect_debt = 0
 
     actual_pos = market.positions(expect_pos_key)
-    (actual_notional, actual_debt, _, _, _) = actual_pos
+    (actual_notional, actual_debt, _, _, _, _) = actual_pos
 
     assert expect_notional == actual_notional
     assert expect_debt == actual_debt

--- a/tests/markets/test_slippage.py
+++ b/tests/markets/test_slippage.py
@@ -100,7 +100,6 @@ def test_unwind_when_price_limit_is_breached(market, feed, alice, factory, ovl,
                       input_price_limit, {"from": alice})
     pos_id = tx.return_value
 
-    # TODO: build() should take in OI amount to ultimately have
     # get position info
     pos_key = get_position_key(alice.address, pos_id)
     pos = market.positions(pos_key)

--- a/tests/markets/test_slippage.py
+++ b/tests/markets/test_slippage.py
@@ -18,6 +18,7 @@ def test_build_when_price_limit_is_breached(market, feed, alice, ovl, is_long):
     expect_pos_id = market.nextPositionId()
 
     # build attributes
+    # TODO: oi => notional
     oi = Decimal(100)
     leverage = Decimal(1.5)
 
@@ -31,9 +32,11 @@ def test_build_when_price_limit_is_breached(market, feed, alice, ovl, is_long):
 
     # calculate expected entry price
     # NOTE: ask(), bid() tested in test_price.py
+    # NOTE: capNotional(), capOi() tested in test_oi_cap.py
     data = feed.latest()
-    cap_oi = Decimal(market.capOiAdjustedForBounds(data, market.capOi())/1e18)
-    volume = int((oi / cap_oi) * Decimal(1e18))
+    cap_notional = Decimal(market.capNotionalAdjustedForBounds(
+        data, market.capNotional())) / Decimal(1e18)
+    volume = int((oi / cap_notional) * Decimal(1e18))
     price = market.ask(data, volume) if is_long else market.bid(data, volume)
 
     # input values for tx
@@ -68,7 +71,7 @@ def test_build_when_price_limit_is_breached(market, feed, alice, ovl, is_long):
 def test_unwind_when_price_limit_is_breached(market, feed, alice, factory, ovl,
                                              is_long):
     # build attributes
-    oi = Decimal(100)
+    notional = Decimal(100)
     leverage = Decimal(1.5)
 
     # tolerance
@@ -79,8 +82,8 @@ def test_unwind_when_price_limit_is_breached(market, feed, alice, factory, ovl,
 
     # calculate expected pos info data
     trading_fee_rate = Decimal(market.tradingFeeRate() / 1e18)
-    collateral, oi, debt, trade_fee \
-        = calculate_position_info(oi, leverage, trading_fee_rate)
+    collateral, notional, debt, trade_fee \
+        = calculate_position_info(notional, leverage, trading_fee_rate)
 
     # input values for tx
     input_collateral = int((collateral) * Decimal(1e18))
@@ -97,10 +100,20 @@ def test_unwind_when_price_limit_is_breached(market, feed, alice, factory, ovl,
                       input_price_limit, {"from": alice})
     pos_id = tx.return_value
 
+    # TODO: build() should take in OI amount to ultimately have
+    # get position info
+    pos_key = get_position_key(alice.address, pos_id)
+    pos = market.positions(pos_key)
+    (actual_notional, _, _, _, actual_entry_price) = pos
+    oi = Decimal(actual_notional) / Decimal(actual_entry_price)
+
     # calculate expected exit price
     # NOTE: ask(), bid() tested in test_price.py
+    # NOTE: capNotional(), capOi() tested in test_oi_cap.py
     data = feed.latest()
-    cap_oi = Decimal(market.capOiAdjustedForBounds(data, market.capOi())/1e18)
+    cap_notional = Decimal(market.capNotionalAdjustedForBounds(
+        data, market.capNotional())) / Decimal(1e18)
+    cap_oi = Decimal(market.capOi(data, cap_notional))
     volume = int((oi / cap_oi) * Decimal(1e18))
     price = market.bid(data, volume) if is_long else market.ask(data, volume)
 
@@ -121,11 +134,11 @@ def test_unwind_when_price_limit_is_breached(market, feed, alice, factory, ovl,
 
     # check all oi shares removed
     expect_pos_key = get_position_key(alice.address, input_pos_id)
-    expect_oi_shares = 0
+    expect_notional = 0
     expect_debt = 0
 
     actual_pos = market.positions(expect_pos_key)
-    (actual_oi_shares, actual_debt, _, _, _) = actual_pos
+    (actual_notional, actual_debt, _, _, _) = actual_pos
 
-    assert expect_oi_shares == actual_oi_shares
+    assert expect_notional == actual_notional
     assert expect_debt == actual_debt

--- a/tests/markets/test_unwind.py
+++ b/tests/markets/test_unwind.py
@@ -908,7 +908,7 @@ def test_unwind_mints_when_profitable(mock_market, mock_feed,
         == "0x0000000000000000000000000000000000000000"
     assert tx.events["Transfer"][0]['to'] == mock_market.address
     assert int(tx.events["Transfer"][0]['value']) == approx(expect_mint,
-                                                            rel=1e-4)
+                                                            rel=1e-3)
 
 
 # NOTE: use mock market to change exit price to whatever
@@ -1018,7 +1018,7 @@ def test_unwind_burns_when_not_profitable(mock_market, mock_feed,
     assert tx.events["Transfer"][0]['to'] \
         == "0x0000000000000000000000000000000000000000"
     assert int(tx.events["Transfer"][0]['value']) == approx(expect_burn,
-                                                            rel=1e-4)
+                                                            rel=1e-3)
 
 
 # NOTE: use mock market to change exit price to whatever

--- a/tests/markets/test_unwind.py
+++ b/tests/markets/test_unwind.py
@@ -53,7 +53,7 @@ def test_unwind_updates_position(market, feed, alice, rando, ovl,
     # get position info
     pos_key = get_position_key(alice.address, pos_id)
     (expect_oi_shares, expect_debt, expect_is_long, expect_liquidated,
-     expect_entry_price) = market.positions(pos_key)
+     expect_entry_price, _) = market.positions(pos_key)
 
     # mine the chain forward for some time difference with build and unwind
     # funding should occur within this interval.
@@ -103,7 +103,7 @@ def test_unwind_updates_position(market, feed, alice, rando, ovl,
 
     # check expected pos attributes match actual after unwind
     (actual_oi_shares, actual_debt, actual_is_long, actual_liquidated,
-     actual_entry_price) = market.positions(pos_key)
+     actual_entry_price, _) = market.positions(pos_key)
 
     assert int(actual_oi_shares) == approx(expect_oi_shares)
     assert int(actual_debt) == approx(expect_debt)
@@ -172,7 +172,7 @@ def test_unwind_removes_oi(market, feed, alice, rando, ovl,
     # get position info
     pos_key = get_position_key(alice.address, pos_id)
     (expect_oi_shares, expect_debt, expect_is_long, expect_liquidated,
-     expect_entry_price) = market.positions(pos_key)
+     expect_entry_price, _) = market.positions(pos_key)
 
     # mine the chain forward for some time difference with build and unwind
     # funding should occur within this interval.
@@ -253,7 +253,7 @@ def test_unwind_updates_market(market, alice, ovl):
     # get position info
     pos_key = get_position_key(alice.address, pos_id)
     (expect_oi_shares, expect_debt, expect_is_long, expect_liquidated,
-     expect_entry_price) = market.positions(pos_key)
+     expect_entry_price, _) = market.positions(pos_key)
 
     # cache prior timestamp update last value
     prior_timestamp_update_last = market.timestampUpdateLast()
@@ -319,7 +319,7 @@ def test_unwind_registers_volume(market, feed, alice, rando, ovl,
     # get position info
     pos_key = get_position_key(alice.address, pos_id)
     (expect_oi_shares, expect_debt, expect_is_long, expect_liquidated,
-     expect_entry_price) = market.positions(pos_key)
+     expect_entry_price, _) = market.positions(pos_key)
 
     # mine the chain forward for some time difference with build and unwind
     # funding should occur within this interval.
@@ -427,7 +427,7 @@ def test_unwind_registers_mint(market, feed, alice, rando, ovl,
     # get position info
     pos_key = get_position_key(alice.address, pos_id)
     (expect_oi_shares, expect_debt, expect_is_long, expect_liquidated,
-     expect_entry_price) = market.positions(pos_key)
+     expect_entry_price, _) = market.positions(pos_key)
 
     # mine the chain forward for some time difference with build and unwind
     # funding should occur within this interval.
@@ -523,7 +523,7 @@ def test_unwind_executes_transfers(market, feed, alice, rando, ovl,
     # get position info
     pos_key = get_position_key(alice.address, pos_id)
     (expect_oi_shares, expect_debt, expect_is_long, expect_liquidated,
-     expect_entry_price) = market.positions(pos_key)
+     expect_entry_price, _) = market.positions(pos_key)
 
     # mine the chain forward for some time difference with build and unwind
     # funding should occur within this interval.
@@ -660,7 +660,7 @@ def test_unwind_transfers_value_to_trader(market, feed, alice, rando, ovl,
     # get position info
     pos_key = get_position_key(alice.address, pos_id)
     (expect_oi_shares, expect_debt, expect_is_long, expect_liquidated,
-     expect_entry_price) = market.positions(pos_key)
+     expect_entry_price, _) = market.positions(pos_key)
 
     # mine the chain forward for some time difference with build and unwind
     # funding should occur within this interval.
@@ -750,7 +750,7 @@ def test_unwind_transfers_trading_fees(market, feed, alice, rando, ovl,
     # get position info
     pos_key = get_position_key(alice.address, pos_id)
     (expect_oi_shares, expect_debt, expect_is_long, expect_liquidated,
-     expect_entry_price) = market.positions(pos_key)
+     expect_entry_price, _) = market.positions(pos_key)
 
     # mine the chain forward for some time difference with build and unwind
     # funding should occur within this interval.
@@ -844,7 +844,7 @@ def test_unwind_mints_when_profitable(mock_market, mock_feed,
     # get position info
     pos_key = get_position_key(alice.address, pos_id)
     (expect_oi_shares, expect_debt, expect_is_long, expect_liquidated,
-     expect_entry_price) = mock_market.positions(pos_key)
+     expect_entry_price, _) = mock_market.positions(pos_key)
 
     # mine the chain forward for some time difference with build and unwind
     # funding should occur within this interval.
@@ -947,7 +947,7 @@ def test_unwind_burns_when_not_profitable(mock_market, mock_feed,
     # get position info
     pos_key = get_position_key(alice.address, pos_id)
     (expect_oi_shares, expect_debt, expect_is_long, expect_liquidated,
-     expect_entry_price) = mock_market.positions(pos_key)
+     expect_entry_price, _) = mock_market.positions(pos_key)
 
     # mine the chain forward for some time difference with build and unwind
     # funding should occur within this interval.
@@ -1055,7 +1055,7 @@ def test_unwind_mints_when_greater_than_cap_payoff(mock_market, mock_feed,
     # get position info
     pos_key = get_position_key(alice.address, pos_id)
     (expect_oi_shares, expect_debt, expect_is_long, expect_liquidated,
-     expect_entry_price) = mock_market.positions(pos_key)
+     expect_entry_price, _) = mock_market.positions(pos_key)
 
     # mine the chain forward for some time difference with build and unwind
     # funding should occur within this interval.
@@ -1158,7 +1158,7 @@ def test_unwind_transfers_fees_when_fees_greater_than_value(mock_market,
     # get position info
     pos_key = get_position_key(alice.address, pos_id)
     (expect_oi_shares, expect_debt, expect_is_long, expect_liquidated,
-     expect_entry_price) = mock_market.positions(pos_key)
+     expect_entry_price, _) = mock_market.positions(pos_key)
 
     # mine the chain forward for some time difference with build and unwind
     # funding should occur within this interval.
@@ -1280,7 +1280,7 @@ def test_unwind_floors_value_to_zero_when_position_underwater(mock_market,
     # get position info
     pos_key = get_position_key(alice.address, pos_id)
     (expect_oi_shares, expect_debt, expect_is_long, expect_liquidated,
-     expect_entry_price) = mock_market.positions(pos_key)
+     expect_entry_price, _) = mock_market.positions(pos_key)
 
     # mine the chain forward for some time difference with build and unwind
     # funding should occur within this interval.
@@ -1522,7 +1522,7 @@ def test_unwind_reverts_when_position_liquidated(mock_market, mock_feed,
     # get position info
     pos_key = get_position_key(alice.address, pos_id)
     (expect_oi_shares, expect_debt, expect_is_long, expect_liquidated,
-     expect_entry_price) = mock_market.positions(pos_key)
+     expect_entry_price, _) = mock_market.positions(pos_key)
 
     # mine the chain forward for some time difference with build and liquidate
     # funding should occur within this interval.
@@ -1686,7 +1686,7 @@ def test_multiple_unwind_unwinds_multiple_positions(market, factory, ovl,
         pos_key = get_position_key(trader.address, id)
         expect_pos = market.positions(pos_key)
         (expect_oi_shares, expect_debt, expect_is_long,
-         expect_liquidated, expect_entry_price) = expect_pos
+         expect_liquidated, expect_entry_price, _) = expect_pos
 
         # unwind fraction of position for trader
         _ = market.unwind(id, input_fraction, input_price_limit_trader,
@@ -1695,7 +1695,7 @@ def test_multiple_unwind_unwinds_multiple_positions(market, factory, ovl,
         # get updated actual position attributes
         actual_pos = market.positions(pos_key)
         (actual_oi_shares, actual_debt, actual_is_long,
-         actual_liquidated, actual_entry_price) = actual_pos
+         actual_liquidated, actual_entry_price, _) = actual_pos
 
         # check position info for id has decreased position oi, debt
         expect_oi_shares_unwound = int(expect_oi_shares * fraction)

--- a/tests/markets/test_update.py
+++ b/tests/markets/test_update.py
@@ -14,19 +14,19 @@ def test_update_fetches_from_feed(market, feed, rando):
 
 
 @given(
-    oi_long=strategy('decimal', min_value='0.001', max_value='800000',
-                     places=3),
-    oi_short=strategy('decimal', min_value='0.001', max_value='800000',
-                      places=3))
+    notional_long=strategy('decimal', min_value='0.001', max_value='800000',
+                           places=3),
+    notional_short=strategy('decimal', min_value='0.001', max_value='800000',
+                            places=3))
 def test_update_pays_funding(market, feed, ovl, alice, bob, rando,
-                             oi_long, oi_short):
-    oi_long = oi_long * Decimal(1e18)
-    oi_short = oi_short * Decimal(1e18)
+                             notional_long, notional_short):
+    notional_long = notional_long * Decimal(1e18)
+    notional_short = notional_short * Decimal(1e18)
 
     # calculate expected pos info data
     trading_fee_rate = Decimal(market.tradingFeeRate() / 1e18)
-    approve_collateral_long = oi_long * (1 + trading_fee_rate)
-    approve_collateral_short = oi_short * (1 + trading_fee_rate)
+    approve_collateral_long = notional_long * (1 + trading_fee_rate)
+    approve_collateral_short = notional_short * (1 + trading_fee_rate)
 
     # approve collateral amounts
     ovl.approve(market, approve_collateral_long, {"from": alice})
@@ -34,8 +34,8 @@ def test_update_pays_funding(market, feed, ovl, alice, bob, rando,
 
     # build long and short positions for oi
     # NOTE: build() tests in test_build.py
-    _ = market.build(oi_long, 1e18, True, 2**256-1, {"from": alice})
-    _ = market.build(oi_short, 1e18, False, 0, {"from": bob})
+    _ = market.build(notional_long, 1e18, True, 2**256-1, {"from": alice})
+    _ = market.build(notional_short, 1e18, False, 0, {"from": bob})
 
     # get values prior to mine chain
     expect_oi_long = market.oiLong()

--- a/tests/markets/utils.py
+++ b/tests/markets/utils.py
@@ -3,17 +3,17 @@ from decimal import Decimal
 from hexbytes import HexBytes
 
 
-def calculate_position_info(oi: Decimal,
+def calculate_position_info(notional: Decimal,
                             leverage: Decimal,
                             trading_fee_rate: Decimal) -> (Decimal, Decimal,
                                                            Decimal, Decimal):
     """
     Returns position attributes in decimal format (int / 1e18)
     """
-    collateral = oi / leverage
-    trade_fee = oi * trading_fee_rate
-    debt = oi - collateral
-    return collateral, oi, debt, trade_fee
+    collateral = notional / leverage
+    trade_fee = notional * trading_fee_rate
+    debt = notional - collateral
+    return collateral, notional, debt, trade_fee
 
 
 def get_position_key(owner: str, id: int) -> HexBytes:

--- a/tests/markets/utils.py
+++ b/tests/markets/utils.py
@@ -1,6 +1,7 @@
 from brownie import web3
 from decimal import Decimal
 from hexbytes import HexBytes
+from typing import Any
 
 
 def calculate_position_info(notional: Decimal,
@@ -22,3 +23,14 @@ def get_position_key(owner: str, id: int) -> HexBytes:
     from positions mapping
     """
     return web3.solidityKeccak(['address', 'uint256'], [owner, id])
+
+
+def mid_from_feed(data: Any) -> float:
+    """
+    Returns mid price from oracle feed data
+    """
+    (_, _, _, price_micro, price_macro, _, _, _) = data
+    ask = max(price_micro, price_macro)
+    bid = min(price_micro, price_macro)
+    mid = (ask + bid) / 2
+    return mid


### PR DESCRIPTION
Implements modifications to funding from [note 11 in OIPs](https://oips.overlay.market/notes/note-11).

Modifies:

- Open interest to be the *number of contracts* (i.e. notional size in OVL / market price): will properly account for differences in entry price on either long or short side when examining imbalance liability
- Portion of funding payments are burned at each update to account for protocol's pro-rata share of the open interest imbalance liability