### PR TITLE
Configure Brownie for Arbitrum

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 V1 core smart contracts
 
-
 ## Requirements
 
 To run the project you need:
@@ -19,19 +18,27 @@ To run the project you need:
 ```
 # required environment variables
 export WEB3_INFURA_PROJECT_ID=<INFURA_TOKEN>
-export ETHERSCAN_TOKEN=<ETHERSCAN_TOKEN>
+export ARBISCAN_TOKEN=<ETHERSCAN_TOKEN>
+```
+
+```
+# add Arbitrum Fork
+brownie networks add Development arbitrum-main-fork name="Ganache-CLI (Aribtrum-Mainnet Fork)" host=http://127.0.0.1 cmd=ganache-cli accounts=10 evm_version=istanbul fork=arbitrum-main mnemonic=brownie port=8545
+```
+
+```
+# modify network configuration to use API key
+brownie networks modify arbitrum-main host="https://arbitrum-mainnet.infura.io/v3/\$WEB3_INFURA_PROJECT_ID" provider=infura
 ```
 
 To generate the required tokens, see
 
-- `ETHERSCAN_TOKEN`: Creating an API key in [Etherscan's API docs](https://docs.etherscan.io/getting-started/viewing-api-usage-statistics)
+- `ARBISCAN_TOKEN`: Creating an API key in [Arbiscan's API docs](https://docs.arbiscan.io/getting-started/viewing-api-usage-statistics)
 - `WEB3_INFURA_PROJECT_ID`: Getting Started in [Infura's API docs](https://infura.io/docs)
-
 
 ## Diagram
 
 ![diagram](./docs/assets/diagram.svg)
-
 
 ## Modules
 
@@ -40,7 +47,6 @@ V1 core relies on three modules:
 - [Markets Module](#markets-module)
 - [Feeds Module](#feeds-module)
 - [OVL Module](#ovl-module)
-
 
 ### Markets Module
 
@@ -76,7 +82,6 @@ For each market contract, there is an associated feed contract that delivers the
 
 All markets are implemented by the contract `OverlayV1Market.sol`, regardless of the underlying feed type.
 
-
 ### Feeds Module
 
 The feed contract ingests the data stream directly from the oracle provider and formats the data in a format consumable by any market contract. The feed contract is limited to a single core external view function
@@ -105,17 +110,16 @@ library Oracle {
   }
 }
 ```
+
 from the [`Oracle.sol`](./contracts/libraries/Oracle.sol) library. `Oracle.Data` is consumed by each deployment of `OverlayV1Market.sol` for traders to take positions on the market of interest.
 
 For each oracle provider supported, there should be a specific implementation of a feed contract that inherits from `OverlayV1Feed.sol` (e.g. [`OverlayV1UniswapV3Feed.sol`](./contracts/feeds/uniswapv3/OverlayV1UniswapV3Feed.sol) for Uniswap V3 pools).
-
 
 ### OVL Module
 
 The OVL module consists of an ERC20 token with permissioned mint and burn functions. Upon initialization, markets must be given permission to mint and burn OVL to compensate traders for their PnL on positions.
 
 [`OverlayV1Factory.sol`](./contracts/OverlayV1Factory.sol) grants these mint and burn permissions on a call to `deployMarket()`. Because of this, the factory contract must have admin privileges on the OVL token prior to deploying markets.
-
 
 ## Deployment Process
 

--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -1,6 +1,6 @@
 # use Ganache's forked mainnet mode as the default network
 networks:
-  default: mainnet-fork
+  default: arbitrum-main-fork
 
 # automatically fetch contract sources from Etherscan
 autofetch_sources: True

--- a/contracts/OverlayV1Factory.sol
+++ b/contracts/OverlayV1Factory.sol
@@ -31,7 +31,7 @@ contract OverlayV1Factory is IOverlayV1Factory {
         1e14, // MIN_TRADING_FEE_RATE = 0.01% (1 bps)
         0.000_001e18, // MIN_MINIMUM_COLLATERAL = 1e-6 OVL
         0.01e14, // MIN_PRICE_DRIFT_UPPER_LIMIT = 0.01 bps/s
-        0 // MIN_AVERAGE_BLOCK_TIME = 0s
+        1 // MIN_AVERAGE_BLOCK_TIME = 0s
     ];
     uint256[15] public PARAMS_MAX = [
         0.04e14, // MAX_K = ~ 1000 bps / 8 hr
@@ -52,12 +52,7 @@ contract OverlayV1Factory is IOverlayV1Factory {
     ];
 
     // event for risk param updates
-    event ParamUpdated(
-        address indexed user,
-        address indexed market,
-        Risk.Parameters name,
-        uint256 value
-    );
+    event ParamUpdated(address indexed user, address indexed market, Risk.Parameters name, uint256 value);
 
     // event for emergency shutdown
     event EmergencyShutdown(address indexed user, address indexed market);
@@ -125,11 +120,11 @@ contract OverlayV1Factory is IOverlayV1Factory {
 
     /// @dev deploys a new market contract
     /// @return market_ address of the new market
-    function deployMarket(
-        address feedFactory,
-        address feed,
-        uint256[15] calldata params
-    ) external onlyGovernor returns (address market_) {
+    function deployMarket(address feedFactory, address feed, uint256[15] calldata params)
+        external
+        onlyGovernor
+        returns (address market_)
+    {
         // check feed and feed factory are available for a new market
         _checkFeed(feedFactory, feed);
 
@@ -176,11 +171,7 @@ contract OverlayV1Factory is IOverlayV1Factory {
     }
 
     /// @notice Setter for per-market risk parameters adjustable by governance
-    function setRiskParam(
-        address feed,
-        Risk.Parameters name,
-        uint256 value
-    ) external onlyGovernor {
+    function setRiskParam(address feed, Risk.Parameters name, uint256 value) external onlyGovernor {
         _checkRiskParam(name, value);
         OverlayV1Market market = OverlayV1Market(getMarket[feed]);
         market.setRiskParam(name, value);

--- a/tests/abi/pool.json
+++ b/tests/abi/pool.json
@@ -1,0 +1,988 @@
+[
+    {
+        "inputs": [],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "owner",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "int24",
+                "name": "tickLower",
+                "type": "int24"
+            },
+            {
+                "indexed": true,
+                "internalType": "int24",
+                "name": "tickUpper",
+                "type": "int24"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint128",
+                "name": "amount",
+                "type": "uint128"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount0",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount1",
+                "type": "uint256"
+            }
+        ],
+        "name": "Burn",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "owner",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "int24",
+                "name": "tickLower",
+                "type": "int24"
+            },
+            {
+                "indexed": true,
+                "internalType": "int24",
+                "name": "tickUpper",
+                "type": "int24"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint128",
+                "name": "amount0",
+                "type": "uint128"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint128",
+                "name": "amount1",
+                "type": "uint128"
+            }
+        ],
+        "name": "Collect",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint128",
+                "name": "amount0",
+                "type": "uint128"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint128",
+                "name": "amount1",
+                "type": "uint128"
+            }
+        ],
+        "name": "CollectProtocol",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount0",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount1",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "paid0",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "paid1",
+                "type": "uint256"
+            }
+        ],
+        "name": "Flash",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint16",
+                "name": "observationCardinalityNextOld",
+                "type": "uint16"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint16",
+                "name": "observationCardinalityNextNew",
+                "type": "uint16"
+            }
+        ],
+        "name": "IncreaseObservationCardinalityNext",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint160",
+                "name": "sqrtPriceX96",
+                "type": "uint160"
+            },
+            {
+                "indexed": false,
+                "internalType": "int24",
+                "name": "tick",
+                "type": "int24"
+            }
+        ],
+        "name": "Initialize",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "owner",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "int24",
+                "name": "tickLower",
+                "type": "int24"
+            },
+            {
+                "indexed": true,
+                "internalType": "int24",
+                "name": "tickUpper",
+                "type": "int24"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint128",
+                "name": "amount",
+                "type": "uint128"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount0",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount1",
+                "type": "uint256"
+            }
+        ],
+        "name": "Mint",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint8",
+                "name": "feeProtocol0Old",
+                "type": "uint8"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint8",
+                "name": "feeProtocol1Old",
+                "type": "uint8"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint8",
+                "name": "feeProtocol0New",
+                "type": "uint8"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint8",
+                "name": "feeProtocol1New",
+                "type": "uint8"
+            }
+        ],
+        "name": "SetFeeProtocol",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "int256",
+                "name": "amount0",
+                "type": "int256"
+            },
+            {
+                "indexed": false,
+                "internalType": "int256",
+                "name": "amount1",
+                "type": "int256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint160",
+                "name": "sqrtPriceX96",
+                "type": "uint160"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint128",
+                "name": "liquidity",
+                "type": "uint128"
+            },
+            {
+                "indexed": false,
+                "internalType": "int24",
+                "name": "tick",
+                "type": "int24"
+            }
+        ],
+        "name": "Swap",
+        "type": "event"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "int24",
+                "name": "tickLower",
+                "type": "int24"
+            },
+            {
+                "internalType": "int24",
+                "name": "tickUpper",
+                "type": "int24"
+            },
+            {
+                "internalType": "uint128",
+                "name": "amount",
+                "type": "uint128"
+            }
+        ],
+        "name": "burn",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "amount0",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount1",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "internalType": "int24",
+                "name": "tickLower",
+                "type": "int24"
+            },
+            {
+                "internalType": "int24",
+                "name": "tickUpper",
+                "type": "int24"
+            },
+            {
+                "internalType": "uint128",
+                "name": "amount0Requested",
+                "type": "uint128"
+            },
+            {
+                "internalType": "uint128",
+                "name": "amount1Requested",
+                "type": "uint128"
+            }
+        ],
+        "name": "collect",
+        "outputs": [
+            {
+                "internalType": "uint128",
+                "name": "amount0",
+                "type": "uint128"
+            },
+            {
+                "internalType": "uint128",
+                "name": "amount1",
+                "type": "uint128"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "internalType": "uint128",
+                "name": "amount0Requested",
+                "type": "uint128"
+            },
+            {
+                "internalType": "uint128",
+                "name": "amount1Requested",
+                "type": "uint128"
+            }
+        ],
+        "name": "collectProtocol",
+        "outputs": [
+            {
+                "internalType": "uint128",
+                "name": "amount0",
+                "type": "uint128"
+            },
+            {
+                "internalType": "uint128",
+                "name": "amount1",
+                "type": "uint128"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "factory",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "fee",
+        "outputs": [
+            {
+                "internalType": "uint24",
+                "name": "",
+                "type": "uint24"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "feeGrowthGlobal0X128",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "feeGrowthGlobal1X128",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount0",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount1",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "flash",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint16",
+                "name": "observationCardinalityNext",
+                "type": "uint16"
+            }
+        ],
+        "name": "increaseObservationCardinalityNext",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint160",
+                "name": "sqrtPriceX96",
+                "type": "uint160"
+            }
+        ],
+        "name": "initialize",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "liquidity",
+        "outputs": [
+            {
+                "internalType": "uint128",
+                "name": "",
+                "type": "uint128"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "maxLiquidityPerTick",
+        "outputs": [
+            {
+                "internalType": "uint128",
+                "name": "",
+                "type": "uint128"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "internalType": "int24",
+                "name": "tickLower",
+                "type": "int24"
+            },
+            {
+                "internalType": "int24",
+                "name": "tickUpper",
+                "type": "int24"
+            },
+            {
+                "internalType": "uint128",
+                "name": "amount",
+                "type": "uint128"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "mint",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "amount0",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount1",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "name": "observations",
+        "outputs": [
+            {
+                "internalType": "uint32",
+                "name": "blockTimestamp",
+                "type": "uint32"
+            },
+            {
+                "internalType": "int56",
+                "name": "tickCumulative",
+                "type": "int56"
+            },
+            {
+                "internalType": "uint160",
+                "name": "secondsPerLiquidityCumulativeX128",
+                "type": "uint160"
+            },
+            {
+                "internalType": "bool",
+                "name": "initialized",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint32[]",
+                "name": "secondsAgos",
+                "type": "uint32[]"
+            }
+        ],
+        "name": "observe",
+        "outputs": [
+            {
+                "internalType": "int56[]",
+                "name": "tickCumulatives",
+                "type": "int56[]"
+            },
+            {
+                "internalType": "uint160[]",
+                "name": "secondsPerLiquidityCumulativeX128s",
+                "type": "uint160[]"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "name": "positions",
+        "outputs": [
+            {
+                "internalType": "uint128",
+                "name": "liquidity",
+                "type": "uint128"
+            },
+            {
+                "internalType": "uint256",
+                "name": "feeGrowthInside0LastX128",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "feeGrowthInside1LastX128",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint128",
+                "name": "tokensOwed0",
+                "type": "uint128"
+            },
+            {
+                "internalType": "uint128",
+                "name": "tokensOwed1",
+                "type": "uint128"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "protocolFees",
+        "outputs": [
+            {
+                "internalType": "uint128",
+                "name": "token0",
+                "type": "uint128"
+            },
+            {
+                "internalType": "uint128",
+                "name": "token1",
+                "type": "uint128"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint8",
+                "name": "feeProtocol0",
+                "type": "uint8"
+            },
+            {
+                "internalType": "uint8",
+                "name": "feeProtocol1",
+                "type": "uint8"
+            }
+        ],
+        "name": "setFeeProtocol",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "slot0",
+        "outputs": [
+            {
+                "internalType": "uint160",
+                "name": "sqrtPriceX96",
+                "type": "uint160"
+            },
+            {
+                "internalType": "int24",
+                "name": "tick",
+                "type": "int24"
+            },
+            {
+                "internalType": "uint16",
+                "name": "observationIndex",
+                "type": "uint16"
+            },
+            {
+                "internalType": "uint16",
+                "name": "observationCardinality",
+                "type": "uint16"
+            },
+            {
+                "internalType": "uint16",
+                "name": "observationCardinalityNext",
+                "type": "uint16"
+            },
+            {
+                "internalType": "uint8",
+                "name": "feeProtocol",
+                "type": "uint8"
+            },
+            {
+                "internalType": "bool",
+                "name": "unlocked",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "int24",
+                "name": "tickLower",
+                "type": "int24"
+            },
+            {
+                "internalType": "int24",
+                "name": "tickUpper",
+                "type": "int24"
+            }
+        ],
+        "name": "snapshotCumulativesInside",
+        "outputs": [
+            {
+                "internalType": "int56",
+                "name": "tickCumulativeInside",
+                "type": "int56"
+            },
+            {
+                "internalType": "uint160",
+                "name": "secondsPerLiquidityInsideX128",
+                "type": "uint160"
+            },
+            {
+                "internalType": "uint32",
+                "name": "secondsInside",
+                "type": "uint32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+            },
+            {
+                "internalType": "bool",
+                "name": "zeroForOne",
+                "type": "bool"
+            },
+            {
+                "internalType": "int256",
+                "name": "amountSpecified",
+                "type": "int256"
+            },
+            {
+                "internalType": "uint160",
+                "name": "sqrtPriceLimitX96",
+                "type": "uint160"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "swap",
+        "outputs": [
+            {
+                "internalType": "int256",
+                "name": "amount0",
+                "type": "int256"
+            },
+            {
+                "internalType": "int256",
+                "name": "amount1",
+                "type": "int256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "int16",
+                "name": "",
+                "type": "int16"
+            }
+        ],
+        "name": "tickBitmap",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "tickSpacing",
+        "outputs": [
+            {
+                "internalType": "int24",
+                "name": "",
+                "type": "int24"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "int24",
+                "name": "",
+                "type": "int24"
+            }
+        ],
+        "name": "ticks",
+        "outputs": [
+            {
+                "internalType": "uint128",
+                "name": "liquidityGross",
+                "type": "uint128"
+            },
+            {
+                "internalType": "int128",
+                "name": "liquidityNet",
+                "type": "int128"
+            },
+            {
+                "internalType": "uint256",
+                "name": "feeGrowthOutside0X128",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "feeGrowthOutside1X128",
+                "type": "uint256"
+            },
+            {
+                "internalType": "int56",
+                "name": "tickCumulativeOutside",
+                "type": "int56"
+            },
+            {
+                "internalType": "uint160",
+                "name": "secondsPerLiquidityOutsideX128",
+                "type": "uint160"
+            },
+            {
+                "internalType": "uint32",
+                "name": "secondsOutside",
+                "type": "uint32"
+            },
+            {
+                "internalType": "bool",
+                "name": "initialized",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "token0",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "token1",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    }
+]

--- a/tests/factories/feed/univ3/conftest.py
+++ b/tests/factories/feed/univ3/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import json
 from brownie import (
     Contract, OverlayV1UniswapV3Factory, OverlayV1NoReserveUniswapV3Factory
 )
@@ -21,18 +22,18 @@ def bob(accounts):
 
 @pytest.fixture(scope="module")
 def dai():
-    yield Contract.from_explorer("0x6B175474E89094C44Da98b954EedeAC495271d0F")
+    yield Contract.from_explorer("0xda10009cbd5d07dd0cecc66161fc93d7c9000da1")
 
 
 @pytest.fixture(scope="module")
 def weth():
-    yield Contract.from_explorer("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
+    yield Contract.from_explorer("0x82aF49447D8a07e3bd95BD0d56f35241523fBab1")
 
 
 @pytest.fixture(scope="module")
 def uni():
     # to be used as example ovl
-    yield Contract.from_explorer("0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984")
+    yield Contract.from_explorer("0xfa7f8980b0f1e64a2062791cc3b0871572f1f7f0")
 
 
 @pytest.fixture(scope="module")
@@ -41,17 +42,21 @@ def uni_factory():
 
 
 @pytest.fixture(scope="module")
-def pool_daiweth_30bps():
-    yield Contract.from_explorer("0xC2e9F25Be6257c210d7Adf0D4Cd6E3E881ba25f8")
+def pool_daiweth_30bps(abi=None):
+    with open(f'tests/abi/pool.json') as f:
+        abi = json.load(f)
+    yield Contract.from_abi('Contract', "0xA961F0473dA4864C5eD28e00FcC53a3AAb056c1b", abi)
 
 
 @pytest.fixture(scope="module")
-def pool_uniweth_30bps():
+def pool_uniweth_30bps(abi=None):
     # to be used as example ovlweth pool
-    yield Contract.from_explorer("0x1d42064Fc4Beb5F8aAF85F4617AE8b3b5B8Bd801")
+    with open(f'tests/abi/pool.json') as f:
+        abi = json.load(f)
+    yield Contract.from_abi('Contract', "0xC24f7d8E51A64dc1238880BD00bb961D54cbeb29", abi)
 
 
-@pytest.fixture(scope="module", params=[(600, 1800, 240, 15)])
+@pytest.fixture(scope="module", params=[(600, 1500, 240, 15)])
 def create_factory_without_reserve(gov, uni_factory, weth, request):
     micro, macro, cardinality, block_time = request.param
     uni_fact = uni_factory.address
@@ -76,7 +81,7 @@ def factory_without_reserve(create_factory_without_reserve):
 
 
 # TODO: change params to (600, 3600, 300, 14)
-@pytest.fixture(scope="module", params=[(600, 1800, 240, 15)])
+@pytest.fixture(scope="module", params=[(600, 1500, 240, 15)])
 def create_factory(gov, uni_factory, weth, uni, request):
     micro, macro, cardinality, block_time = request.param
     uni_fact = uni_factory.address

--- a/tests/factories/feed/univ3/test_conftest.py
+++ b/tests/factories/feed/univ3/test_conftest.py
@@ -2,7 +2,7 @@ def test_factory_fixture(factory, uni_factory, weth, uni):
     assert factory.uniV3Factory() == uni_factory
     assert factory.ovl() == uni  # UNI acts as ovl for testing
     assert factory.microWindow() == 600
-    assert factory.macroWindow() == 1800
+    assert factory.macroWindow() == 1500
     assert factory.observationCardinalityMinimum() == 240
 
 
@@ -15,11 +15,11 @@ def test_token_fixtures(dai, weth, uni):
 def test_pool_fixtures(dai, weth, uni, uni_factory, pool_daiweth_30bps,
                        pool_uniweth_30bps):
     assert pool_daiweth_30bps.fee() == 3000
-    assert pool_daiweth_30bps.token0() == dai
-    assert pool_daiweth_30bps.token1() == weth
+    assert pool_daiweth_30bps.token0() == weth
+    assert pool_daiweth_30bps.token1() == dai
     assert pool_daiweth_30bps == uni_factory.getPool(dai, weth, 3000)
 
     assert pool_uniweth_30bps.fee() == 3000
-    assert pool_uniweth_30bps.token0() == uni
-    assert pool_uniweth_30bps.token1() == weth
+    assert pool_uniweth_30bps.token0() == weth
+    assert pool_uniweth_30bps.token1() == uni
     assert pool_uniweth_30bps == uni_factory.getPool(uni, weth, 3000)

--- a/tests/factories/market/conftest.py
+++ b/tests/factories/market/conftest.py
@@ -176,7 +176,7 @@ def create_factory(gov, guardian, fee_recipient, request, ovl, governor_role,
         trade_fee = 750000000000000
         min_collateral = 100000000000000
         price_drift_upper_limit = 10000000000000  # 0.001% per sec
-        average_block_time = 14
+        average_block_time = 1
 
         params = (k, lmbda, delta, cap_payoff, cap_notional, cap_leverage,
                   circuit_breaker_window, circuit_breaker_mint_target,

--- a/tests/factories/market/test_conftest.py
+++ b/tests/factories/market/test_conftest.py
@@ -39,7 +39,7 @@ def test_factory_fixture(factory, fee_recipient, feed_factory, feed_three, ovl,
         100000000000000,  # MIN_TRADING_FEE_RATE = 0.01 % (1 bps)
         1000000000000,  # MIN_MINIMUM_COLLATERAL= 1e-6 OVL
         1000000000000,  # MIN_PRICE_DRIFT_UPPER_LIMIT= 0.01 bps/s
-        0  # MIN_AVERAGE_BLOCK_TIME = 0s
+        1  # MIN_AVERAGE_BLOCK_TIME = 0s
     ]
     actual_params_min = [
         factory.PARAMS_MIN(i) for i in range(len(expect_params_min))

--- a/tests/factories/market/test_deploy_market.py
+++ b/tests/factories/market/test_deploy_market.py
@@ -34,7 +34,7 @@ def test_deploy_market_creates_market(factory, feed_factory, feed_one, ovl,
     expect_trading_fee_rate = 750000000000000
     expect_min_collateral = 100000000000000
     expect_price_drift_upper_limit = 100000000000000
-    expect_average_block_time = 14
+    expect_average_block_time = 1
 
     expect_params = [expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
                      expect_cap_notional, expect_cap_leverage,
@@ -114,7 +114,7 @@ def test_deploy_market_reverts_when_not_gov(factory, feed_factory, feed_two,
     expect_trading_fee_rate = 750000000000000
     expect_min_collateral = 100000000000000
     expect_price_drift_upper_limit = 100000000000000
-    expect_average_block_time = 14
+    expect_average_block_time = 1
 
     expect_params = [expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
                      expect_cap_notional, expect_cap_leverage,
@@ -163,7 +163,7 @@ def test_deploy_market_reverts_when_market_already_exists(factory,
     expect_trading_fee_rate = 750000000000000
     expect_min_collateral = 100000000000000
     expect_price_drift_upper_limit = 100000000000000
-    expect_average_block_time = 14
+    expect_average_block_time = 1
 
     expect_params = [expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
                      expect_cap_notional, expect_cap_leverage,
@@ -208,7 +208,7 @@ def test_deploy_market_reverts_when_feed_factory_not_supported(factory, rando,
     expect_trading_fee_rate = 750000000000000
     expect_min_collateral = 100000000000000
     expect_price_drift_upper_limit = 100000000000000
-    expect_average_block_time = 14
+    expect_average_block_time = 1
 
     expect_params = [expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
                      expect_cap_notional, expect_cap_leverage,
@@ -251,7 +251,7 @@ def test_deploy_market_reverts_when_feed_does_not_exist(factory, feed_factory,
     expect_trading_fee_rate = 750000000000000
     expect_min_collateral = 100000000000000
     expect_price_drift_upper_limit = 100000000000000
-    expect_average_block_time = 14
+    expect_average_block_time = 1
 
     expect_params = [expect_k, expect_lmbda, expect_delta, expect_cap_payoff,
                      expect_cap_notional, expect_cap_leverage,
@@ -297,7 +297,7 @@ def test_deploy_market_reverts_when_param_less_than_min(factory, feed_factory,
         750000000000000,  # expect_trading_fee_rate
         100000000000000,  # expect_min_collateral
         100000000000000,  # expect_price_drift_upper_limit
-        14,  # expect_average_block_time
+        1,  # expect_average_block_time
     ]
 
     for i in range(len(default_params)):
@@ -352,7 +352,7 @@ def test_deploy_market_reverts_when_param_greater_than_max(factory, feed_one,
         750000000000000,  # expect_trading_fee_rate
         100000000000000,  # expect_min_collateral
         100000000000000,  # expect_price_drift_upper_limit
-        14,  # expect_average_block_time
+        1,  # expect_average_block_time
     ]
 
     for i in range(len(default_params)):

--- a/tests/factories/market/test_setters.py
+++ b/tests/factories/market/test_setters.py
@@ -67,7 +67,7 @@ def test_set_risk_param(factory, market, gov):
         550000000000000,  # expect_trading_fee_rate
         200000000000000,  # expect_min_collateral
         12000000000000,  # expect_price_drift_upper_limit
-        14,  # expect_average_block_time
+        1,  # expect_average_block_time
     ]
 
     for i in range(len(default_params)):

--- a/tests/feeds/uniswapv3/conftest.py
+++ b/tests/feeds/uniswapv3/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import json
 from brownie import (
     Contract, OverlayV1UniswapV3Feed, OverlayV1NoReserveUniswapV3Feed
 )
@@ -26,18 +27,18 @@ def rando(accounts):
 
 @pytest.fixture(scope="module")
 def dai():
-    yield Contract.from_explorer("0x6B175474E89094C44Da98b954EedeAC495271d0F")
+    yield Contract.from_explorer("0xda10009cbd5d07dd0cecc66161fc93d7c9000da1")
 
 
 @pytest.fixture(scope="module")
 def weth():
-    yield Contract.from_explorer("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
+    yield Contract.from_explorer("0x82aF49447D8a07e3bd95BD0d56f35241523fBab1")
 
 
 @pytest.fixture(scope="module")
 def uni():
     # to be used as example ovl
-    yield Contract.from_explorer("0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984")
+    yield Contract.from_explorer("0xfa7f8980b0f1e64a2062791cc3b0871572f1f7f0")
 
 
 @pytest.fixture(scope="module")
@@ -46,14 +47,18 @@ def uni_factory():
 
 
 @pytest.fixture(scope="module")
-def pool_daiweth_30bps():
-    yield Contract.from_explorer("0xC2e9F25Be6257c210d7Adf0D4Cd6E3E881ba25f8")
+def pool_daiweth_30bps(abi=None):
+    with open(f'tests/abi/pool.json') as f:
+        abi = json.load(f)
+    yield Contract.from_abi('Contract', "0xA961F0473dA4864C5eD28e00FcC53a3AAb056c1b", abi)
 
 
 @pytest.fixture(scope="module")
-def pool_uniweth_30bps():
+def pool_uniweth_30bps(abi=None):
     # to be used as example ovlweth pool
-    yield Contract.from_explorer("0x1d42064Fc4Beb5F8aAF85F4617AE8b3b5B8Bd801")
+    with open(f'tests/abi/pool.json') as f:
+        abi = json.load(f)
+    yield Contract.from_abi('Contract', "0xC24f7d8E51A64dc1238880BD00bb961D54cbeb29", abi)
 
 
 @pytest.fixture(scope="module", params=[(600, 3600, 200)])

--- a/tests/feeds/uniswapv3/test_conftest.py
+++ b/tests/feeds/uniswapv3/test_conftest.py
@@ -7,13 +7,13 @@ def test_token_fixtures(dai, weth, uni):
 def test_pool_fixtures(dai, weth, uni, uni_factory, pool_daiweth_30bps,
                        pool_uniweth_30bps):
     assert pool_daiweth_30bps.fee() == 3000
-    assert pool_daiweth_30bps.token0() == dai
-    assert pool_daiweth_30bps.token1() == weth
+    assert pool_daiweth_30bps.token0() == weth
+    assert pool_daiweth_30bps.token1() == dai
     assert pool_daiweth_30bps == uni_factory.getPool(dai, weth, 3000)
 
     assert pool_uniweth_30bps.fee() == 3000
-    assert pool_uniweth_30bps.token0() == uni
-    assert pool_uniweth_30bps.token1() == weth
+    assert pool_uniweth_30bps.token0() == weth
+    assert pool_uniweth_30bps.token1() == uni
     assert pool_uniweth_30bps == uni_factory.getPool(uni, weth, 3000)
 
 
@@ -26,8 +26,8 @@ def test_quanto_feed_fixture(dai, weth, uni, pool_daiweth_30bps,
     assert quanto_feed.marketPool() == pool_daiweth_30bps
     assert quanto_feed.ovlXPool() == pool_uniweth_30bps
 
-    assert quanto_feed.marketToken0() == dai
-    assert quanto_feed.marketToken1() == weth
+    assert quanto_feed.marketToken0() == weth
+    assert quanto_feed.marketToken1() == dai
 
     assert quanto_feed.marketBaseToken() == weth
     assert quanto_feed.marketQuoteToken() == dai
@@ -46,8 +46,8 @@ def test_inverse_feed_fixture(dai, weth, uni, pool_daiweth_30bps,
     assert inverse_feed.marketPool() == pool_uniweth_30bps
     assert inverse_feed.ovlXPool() == pool_uniweth_30bps
 
-    assert inverse_feed.marketToken0() == uni
-    assert inverse_feed.marketToken1() == weth
+    assert inverse_feed.marketToken0() == weth
+    assert inverse_feed.marketToken1() == uni
 
     assert inverse_feed.marketBaseToken() == weth
     assert inverse_feed.marketQuoteToken() == uni

--- a/tests/feeds/uniswapv3/test_deploy.py
+++ b/tests/feeds/uniswapv3/test_deploy.py
@@ -1,15 +1,18 @@
 import pytest
+import json
 from brownie import Contract, OverlayV1UniswapV3Feed, reverts
 
 
 @pytest.fixture
 def usdc():
-    yield Contract.from_explorer("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
+    yield Contract.from_explorer("0xaf88d065e77c8cC2239327C5EDb3A432268e5831")
 
 
 @pytest.fixture
-def pool_daiusdc_5bps():
-    yield Contract.from_explorer("0x6c6Bc977E13Df9b0de53b251522280BB72383700")
+def pool_daiusdc_5bps(abi=None):
+    with open(f'tests/abi/pool.json') as f:
+        abi = json.load(f)
+    yield Contract.from_abi('Contract', "0x7CF803e8d82A50504180f417B8bC7a493C0a0503", abi)
 
 
 def test_deploy_feed_reverts_on_market_token_not_weth(gov, dai, usdc, uni,

--- a/tests/markets/conftest.py
+++ b/tests/markets/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import json
 from brownie import (
     Contract, OverlayV1Token, OverlayV1Market, OverlayV1Factory,
     OverlayV1UniswapV3Factory, OverlayV1FeedFactoryMock,
@@ -86,7 +87,7 @@ def ovl(create_token):
 
 
 @pytest.fixture(scope="module", params=[
-    (600, 1800, 1000000000000000000, 2000000000000000000000000)
+    (600, 1500, 1000000000000000000, 2000000000000000000000000)
 ])
 def create_fake_feed(gov, request):
     micro, macro, p, r = request.param
@@ -107,18 +108,18 @@ def fake_feed(create_fake_feed):
 
 @pytest.fixture(scope="module")
 def dai():
-    yield Contract.from_explorer("0x6B175474E89094C44Da98b954EedeAC495271d0F")
+    yield Contract.from_explorer("0xda10009cbd5d07dd0cecc66161fc93d7c9000da1")
 
 
 @pytest.fixture(scope="module")
 def weth():
-    yield Contract.from_explorer("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
+    yield Contract.from_explorer("0x82aF49447D8a07e3bd95BD0d56f35241523fBab1")
 
 
 @pytest.fixture(scope="module")
 def uni():
     # to be used as example ovl
-    yield Contract.from_explorer("0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984")
+    yield Contract.from_explorer("0xFa7F8980b0f1E64A2062791cc3b0871572f1F7f0")
 
 
 @pytest.fixture(scope="module")
@@ -127,18 +128,22 @@ def uni_factory():
 
 
 @pytest.fixture(scope="module")
-def pool_daiweth_30bps():
-    yield Contract.from_explorer("0xC2e9F25Be6257c210d7Adf0D4Cd6E3E881ba25f8")
+def pool_daiweth_30bps(abi=None):
+    with open(f'tests/abi/pool.json') as f:
+        abi = json.load(f)
+    yield Contract.from_abi('Contract', "0xA961F0473dA4864C5eD28e00FcC53a3AAb056c1b", abi)
 
 
 @pytest.fixture(scope="module")
-def pool_uniweth_30bps():
+def pool_uniweth_30bps(abi=None):
     # to be used as example ovlweth pool
-    yield Contract.from_explorer("0x1d42064Fc4Beb5F8aAF85F4617AE8b3b5B8Bd801")
+    with open(f'tests/abi/pool.json') as f:
+        abi = json.load(f)
+    yield Contract.from_abi('Contract', "0xC24f7d8E51A64dc1238880BD00bb961D54cbeb29", abi)
 
 
 # TODO: change params to (600, 3600, 300, 14)
-@pytest.fixture(scope="module", params=[(600, 1800, 240, 15)])
+@pytest.fixture(scope="module", params=[(600, 1500, 200, 15)])
 def create_feed_factory(gov, uni_factory, weth, uni, request):
     micro, macro, cardinality, block_time = request.param
     tok = uni.address
@@ -198,7 +203,7 @@ def feed(create_feed):
     yield create_feed()
 
 
-@pytest.fixture(scope="module", params=[(600, 1800)])
+@pytest.fixture(scope="module", params=[(600, 1500)])
 def create_mock_feed_factory(gov, request):
     micro, macro = request.param
 
@@ -305,7 +310,7 @@ def create_market(gov, ovl):
     750000000000000,  # tradingFeeRate
     100000000000000,  # minCollateral
     25000000000000,  # priceDriftUpperLimit
-    14,  # averageBlockTime
+    1,  # averageBlockTime
 )])
 def mock_market(gov, mock_feed, mock_feed_factory, factory, ovl,
                 create_market, request):
@@ -330,7 +335,7 @@ def mock_market(gov, mock_feed, mock_feed_factory, factory, ovl,
     750000000000000,  # tradingFeeRate
     100000000000000,  # minCollateral
     25000000000000,  # priceDriftUpperLimit
-    14,  # averageBlockTime
+    1,  # averageBlockTime
 )])
 def market(gov, feed, feed_factory, factory, ovl, create_market, request):
     risk_params = request.param

--- a/tests/markets/test_build.py
+++ b/tests/markets/test_build.py
@@ -24,7 +24,7 @@ def isolation(fn_isolation):
 
 
 @given(
-    notional=strategy('decimal', min_value='0.001', max_value='80000',
+    notional=strategy('decimal', min_value='0.001', max_value='8000',
                       places=3),
     leverage=strategy('decimal', min_value='1.0', max_value='5.0', places=3),
     is_long=strategy('bool'))
@@ -125,7 +125,7 @@ def test_build_creates_position(market, feed, ovl, alice, notional, leverage,
 
 
 @given(
-    notional=strategy('decimal', min_value='0.001', max_value='80000',
+    notional=strategy('decimal', min_value='0.001', max_value='8000',
                       places=3),
     leverage=strategy('decimal', min_value='1.0', max_value='5.0', places=3),
     is_long=strategy('bool'))
@@ -280,7 +280,7 @@ def test_build_updates_market(market, ovl, alice):
 
 
 @given(
-    notional=strategy('decimal', min_value='0.001', max_value='80000',
+    notional=strategy('decimal', min_value='0.001', max_value='8000',
                       places=3),
     leverage=strategy('decimal', min_value='1.0', max_value='5.0', places=3),
     is_long=strategy('bool'))
@@ -361,7 +361,7 @@ def test_build_registers_volume(market, feed, ovl, alice, notional, leverage,
 
 
 @given(
-    notional=strategy('decimal', min_value='0.001', max_value='80000',
+    notional=strategy('decimal', min_value='0.001', max_value='8000',
                       places=3),
     leverage=strategy('decimal', min_value='1.0', max_value='5.0', places=3),
     is_long=strategy('bool'))
@@ -413,7 +413,7 @@ def test_build_executes_transfers(market, factory, ovl, alice, notional,
 
 
 @given(
-    notional=strategy('decimal', min_value='0.001', max_value='80000',
+    notional=strategy('decimal', min_value='0.001', max_value='8000',
                       places=3),
     leverage=strategy('decimal', min_value='1.0', max_value='5.0', places=3),
     is_long=strategy('bool'))
@@ -460,7 +460,7 @@ def test_build_transfers_collateral_to_market(market, ovl, alice, notional,
 
 
 @given(
-    notional=strategy('decimal', min_value='0.001', max_value='80000',
+    notional=strategy('decimal', min_value='0.001', max_value='8000',
                       places=3),
     leverage=strategy('decimal', min_value='1.0', max_value='5.0', places=3),
     is_long=strategy('bool'))

--- a/tests/markets/test_conftest.py
+++ b/tests/markets/test_conftest.py
@@ -17,13 +17,13 @@ def test_token_fixtures(dai, weth, uni):
 def test_pool_fixtures(dai, weth, uni, uni_factory, pool_daiweth_30bps,
                        pool_uniweth_30bps):
     assert pool_daiweth_30bps.fee() == 3000
-    assert pool_daiweth_30bps.token0() == dai
-    assert pool_daiweth_30bps.token1() == weth
+    assert pool_daiweth_30bps.token0() == weth
+    assert pool_daiweth_30bps.token1() == dai
     assert pool_daiweth_30bps == uni_factory.getPool(dai, weth, 3000)
 
     assert pool_uniweth_30bps.fee() == 3000
-    assert pool_uniweth_30bps.token0() == uni
-    assert pool_uniweth_30bps.token1() == weth
+    assert pool_uniweth_30bps.token0() == weth
+    assert pool_uniweth_30bps.token1() == uni
     assert pool_uniweth_30bps == uni_factory.getPool(uni, weth, 3000)
 
 
@@ -42,19 +42,19 @@ def test_feed_fixture(feed, pool_daiweth_30bps, pool_uniweth_30bps, dai, weth,
     assert feed.marketBaseToken() == weth
     assert feed.marketQuoteToken() == dai
     assert feed.microWindow() == 600
-    assert feed.macroWindow() == 1800
+    assert feed.macroWindow() == 1500
 
 
 def test_mock_feed_fixture(mock_feed):
     assert mock_feed.microWindow() == 600
-    assert mock_feed.macroWindow() == 1800
+    assert mock_feed.macroWindow() == 1500
     assert mock_feed.price() == 1000000000000000000
     assert mock_feed.reserve() == 2000000000000000000000000
 
 
 def test_fake_feed_fixture(fake_feed):
     assert fake_feed.microWindow() == 600
-    assert fake_feed.macroWindow() == 1800
+    assert fake_feed.macroWindow() == 1500
     assert fake_feed.price() == 1000000000000000000
     assert fake_feed.reserve() == 2000000000000000000000000
 

--- a/tests/markets/test_initialize.py
+++ b/tests/markets/test_initialize.py
@@ -30,7 +30,7 @@ def test_initialize_creates_market(fake_deployer, ovl, fake_feed,
     trading_fee_rate = 750000000000000
     min_collateral = 100000000000000
     price_drift_upper_limit = 100000000000000
-    average_block_time = 14
+    average_block_time = 1
 
     params = [k, lmbda, delta, cap_payoff, cap_notional, cap_leverage,
               circuit_breaker_window, circuit_breaker_mint_target,
@@ -84,7 +84,7 @@ def test_initialize_reverts_when_not_factory(fake_deployer, fake_feed,
         250000000000000,  # expect_trading_fee_rate
         500000000000000,  # expect_min_collateral
         50000000000000,  # expect_price_drift_upper_limit
-        14,  # expect_average_block_time
+        1,  # expect_average_block_time
     ]
 
     # deploy the market from the deployer
@@ -114,7 +114,7 @@ def test_initialize_reverts_when_price_is_zero(ovl, fake_deployer, fake_feed,
     trading_fee_rate = 750000000000000
     min_collateral = 100000000000000
     price_drift_upper_limit = 100000000000000
-    average_block_time = 14
+    average_block_time = 1
 
     params = [k, lmbda, delta, cap_payoff, cap_notional, cap_leverage,
               circuit_breaker_window, circuit_breaker_mint_target,
@@ -155,7 +155,7 @@ def test_deploy_reverts_when_max_leverage_is_liquidatable(ovl, fake_feed,
     trading_fee_rate = 750000000000000
     min_collateral = 100000000000000
     price_drift_upper_limit = 100000000000000
-    average_block_time = 14
+    average_block_time = 1
 
     params = [k, lmbda, delta, cap_payoff, cap_notional, cap_leverage,
               circuit_breaker_window, circuit_breaker_mint_target,
@@ -192,7 +192,7 @@ def test_deploy_reverts_when_price_drift_exceeds_max_exp(ovl, fake_feed,
     trading_fee_rate = 750000000000000
     min_collateral = 100000000000000
     price_drift_upper_limit = 100000000000000000
-    average_block_time = 14
+    average_block_time = 1
 
     params = [k, lmbda, delta, cap_payoff, cap_notional, cap_leverage,
               circuit_breaker_window, circuit_breaker_mint_target,

--- a/tests/markets/test_setters.py
+++ b/tests/markets/test_setters.py
@@ -31,7 +31,7 @@ def test_set_risk_param(market, factory):
         250000000000000,  # expect_trading_fee_rate
         500000000000000,  # expect_min_collateral
         50000000000000,  # expect_price_drift_upper_limit
-        14,  # expect_average_block_time
+        1,  # expect_average_block_time
     ]
 
     for i in range(len(RiskParameter)):
@@ -64,7 +64,7 @@ def test_set_risk_param_pays_funding(market, feed, factory, ovl, alice):
         250000000000000,  # expect_trading_fee_rate
         500000000000000,  # expect_min_collateral
         50000000000000,  # expect_price_drift_upper_limit
-        14,  # expect_average_block_time
+        1,  # expect_average_block_time
     ]
 
     # build some positions

--- a/tests/markets/test_update.py
+++ b/tests/markets/test_update.py
@@ -16,9 +16,9 @@ def test_update_fetches_from_feed(market, feed, rando):
 
 
 @given(
-    notional_long=strategy('decimal', min_value='0.001', max_value='800000',
+    notional_long=strategy('decimal', min_value='0.001', max_value='80000',
                            places=3),
-    notional_short=strategy('decimal', min_value='0.001', max_value='800000',
+    notional_short=strategy('decimal', min_value='0.001', max_value='80000',
                             places=3))
 def test_update_pays_funding(market, feed, ovl, alice, bob, rando,
                              notional_long, notional_short):


### PR DESCRIPTION
- Modifies `README.md` to add instructions on how to configure Brownie to fork Arbitrum.
- Modifies `brownie-config.yaml` to use Arbitrum fork instead of Ethereum fork
- Adds `pool.json`, this is the ABI of UniswapV3 pools, used when contracts are not verified in Arbiscan.
- Changes _Average Block Time_ in every test to match the Arbitrum configuration.
- Replaces Ethereum contracts addresses with Arbitrum ones.
- Reduces _ Notional Max Value_ in fuzz tests due to the Arbitrum liquidity.