### PR TITLE
Remove brownie dependencies

### DIFF
--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -11,8 +11,8 @@ on:
       - staging
 
 env:
-    # increasing available memory for node reduces issues with ganache crashing
-    # https://nodejs.org/api/cli.html#cli_max_old_space_size_size_in_megabytes
+  # increasing available memory for node reduces issues with ganache crashing
+  # https://nodejs.org/api/cli.html#cli_max_old_space_size_size_in_megabytes
   NODE_OPTIONS: --max_old_space_size=4096
 
 jobs:
@@ -24,7 +24,17 @@ jobs:
         python-version: [3.9]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Run Forge install
+        run: forge install
 
       - name: Create .env
         run: |

--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -8,11 +8,6 @@ autofetch_sources: True
 # automatically load the local .env file
 dotenv: .env
 
-# require OpenZepplin, Uniswap Contracts
-dependencies:
-  - OpenZeppelin/openzeppelin-contracts@4.5.0
-  - smartcontractkit/chainlink-brownie-contracts@0.4.2
-
 # path remapping to support imports from GitHub/NPM
 compiler:
   solc:
@@ -20,5 +15,5 @@ compiler:
     optimizer:
       runs: 800
     remappings:
-      - "@openzeppelin=OpenZeppelin/openzeppelin-contracts@4.5.0"
-      - "@chainlink=smartcontractkit/chainlink-brownie-contracts@0.4.2"
+      - "@openzeppelin/=lib/openzeppelin-contracts/"
+      - "@chainlink/=lib/chainlink/"


### PR DESCRIPTION
Remove step in brownie config where dependencies are imported since we are using foundry too. The idea is to use the same dependencies to test with forge and with brownie.