### PR TITLE
Refactor Position.sol

### DIFF
--- a/contracts/libraries/Position.sol
+++ b/contracts/libraries/Position.sol
@@ -83,7 +83,7 @@ library Position {
     /// @notice Whether the position exists
     /// @dev Is false if position has been liquidated or fraction remaining == 0
     function exists(Info memory self) internal pure returns (bool exists_) {
-        return (!self.liquidated && self.fractionRemaining > 0);
+        return (self.fractionRemaining > 0);
     }
 
     /*///////////////////////////////////////////////////////////////
@@ -317,7 +317,7 @@ library Position {
         uint256 fraction = ONE;
         uint256 posNotionalInitial = notionalInitial(self, fraction);
 
-        if (self.liquidated || self.fractionRemaining == 0) {
+        if (self.fractionRemaining == 0) {
             // already been liquidated or doesn't exist
             // latter covers edge case of val == 0 and MM + liq fee == 0
             return false;

--- a/contracts/libraries/Position.sol
+++ b/contracts/libraries/Position.sol
@@ -102,7 +102,6 @@ library Position {
         pure
         returns (uint16)
     {
-        require(fractionRemoved <= ONE, "OVV1:fraction>max");
         uint256 fractionRemaining = _fractionRemaining(self).mulDown(ONE - fractionRemoved);
         return fractionRemaining.toUint16Fixed();
     }

--- a/contracts/libraries/Position.sol
+++ b/contracts/libraries/Position.sol
@@ -162,8 +162,7 @@ library Position {
     /// @notice accounting for amount of position remaining
     /// @dev use mulUp to avoid rounding leftovers on unwind
     function notionalInitial(Info memory self, uint256 fraction) internal pure returns (uint256) {
-        uint256 fractionRemaining = _fractionRemaining(self);
-        uint256 notionalForRemaining = _notionalInitial(self).mulUp(fractionRemaining);
+        uint256 notionalForRemaining = _notionalInitial(self).mulUp(_fractionRemaining(self));
         return notionalForRemaining.mulUp(fraction);
     }
 
@@ -171,8 +170,7 @@ library Position {
     /// @notice accounting for amount of position remaining
     /// @dev use mulUp to avoid rounding leftovers on unwind
     function oiInitial(Info memory self, uint256 fraction) internal pure returns (uint256) {
-        uint256 fractionRemaining = _fractionRemaining(self);
-        uint256 oiInitialForRemaining = _oiInitial(self).mulUp(fractionRemaining);
+        uint256 oiInitialForRemaining = _oiInitial(self).mulUp(_fractionRemaining(self));
         return oiInitialForRemaining.mulUp(fraction);
     }
 
@@ -189,8 +187,7 @@ library Position {
     /// @notice for amount of position remaining
     /// @dev use mulUp to avoid rounding leftovers on unwind
     function debtInitial(Info memory self, uint256 fraction) internal pure returns (uint256) {
-        uint256 fractionRemaining = _fractionRemaining(self);
-        uint256 debtForRemaining = _debtInitial(self).mulUp(fractionRemaining);
+        uint256 debtForRemaining = _debtInitial(self).mulUp(_fractionRemaining(self));
         return debtForRemaining.mulUp(fraction);
     }
 

--- a/tests/libraries/position/test_fraction.py
+++ b/tests/libraries/position/test_fraction.py
@@ -1,4 +1,3 @@
-from brownie import reverts
 from brownie.test import given, strategy
 from decimal import Decimal
 
@@ -68,37 +67,4 @@ def test_updated_fraction_remaining(position, fraction_remaining,
     # check updated fraction remaining once remove from remaining
     expect = updated_fraction_remaining
     actual = position.updatedFractionRemaining(pos, fraction_removed_256)
-    assert expect == actual
-
-
-def test_updated_fraction_remaining_reverts_when_gt_max(position):
-    notional = 10000000000000000000  # 10
-    debt = 2000000000000000000  # 2
-    is_long = True
-    liquidated = False
-    fraction_remaining = 9000  # 0.9
-
-    mid_price = 100000000000000000000  # 100
-    entry_price = 101000000000000000000  # 101
-
-    mid_tick = price_to_tick(mid_price)
-    entry_tick = price_to_tick(entry_price)
-
-    oi = int((notional / mid_price) * 1000000000000000000)  # 0.1
-    shares_to_oi_ratio = 800000000000000000  # 0.8
-    oi_shares = int(Decimal(oi) * Decimal(shares_to_oi_ratio)
-                    / Decimal(1e18))  # 0.08
-
-    pos = (notional, debt, mid_tick, entry_tick, is_long,
-           liquidated, oi_shares, fraction_remaining)
-
-    # check fails when greater than ONE
-    fraction_removed = 1000000000000000001  # 1 greater than ONE (18 decimals)
-    with reverts("OVV1:fraction>max"):
-        position.updatedFractionRemaining(pos, fraction_removed)
-
-    # check succeeds when equal to ONE
-    fraction_removed = 1000000000000000000
-    expect = 0
-    actual = position.updatedFractionRemaining(pos, fraction_removed)
     assert expect == actual


### PR DESCRIPTION
# Remove unnecessary conditions: 
[`liquidate()` ](https://github.com/overlay-market/v1-core/blob/main/contracts/OverlayV1Market.sol#L464-L467) sets `liquidated` and `fractionRemaining`, so checking both conditions at the same time is redundant. Checking only `fractionRemaining` is enough and saves gas.

https://github.com/overlay-market/v1-core/blob/ad3d152d0cbd54b62f0a38b029ba855afe84293a/contracts/libraries/Position.sol#L86

https://github.com/overlay-market/v1-core/blob/ad3d152d0cbd54b62f0a38b029ba855afe84293a/contracts/libraries/Position.sol#L333

# Remove unnecessary  require statement

This function is only used on market `unwind()` and the same condition is checked before and tested.
## Previous requirement
https://github.com/overlay-market/v1-core/blob/ad3d152d0cbd54b62f0a38b029ba855afe84293a/contracts/OverlayV1Market.sol#L260
## Test
https://github.com/overlay-market/v1-core/blob/ad3d152d0cbd54b62f0a38b029ba855afe84293a/tests/markets/test_unwind.py#L1659
## Removed code
https://github.com/overlay-market/v1-core/blob/ad3d152d0cbd54b62f0a38b029ba855afe84293a/contracts/libraries/Position.sol#L105



