### PR TITLE
Adds RISK_MANAGER role 

### DIFF
--- a/contracts/OverlayV1Factory.sol
+++ b/contracts/OverlayV1Factory.sol
@@ -110,6 +110,12 @@ contract OverlayV1Factory is IOverlayV1Factory {
         _;
     }
 
+    // risk manager modifier for risk parameters
+    modifier onlyRiskManager() {
+        require(ov.hasRole(RISK_MANAGER_ROLE, msg.sender), "OVV1: !riskManager");
+        _;
+    }
+
     constructor(
         address _ov,
         address _feeRecipient,
@@ -199,7 +205,7 @@ contract OverlayV1Factory is IOverlayV1Factory {
     /// @notice Setter for per-market risk parameters adjustable by governance
     function setRiskParam(address feed, Risk.Parameters name, uint256 value)
         external
-        onlyGovernor
+        onlyRiskManager
     {
         _checkRiskParam(name, value);
         OverlayV1Market market = OverlayV1Market(getMarket[feed]);

--- a/contracts/interfaces/IOverlayV1Token.sol
+++ b/contracts/interfaces/IOverlayV1Token.sol
@@ -9,6 +9,7 @@ bytes32 constant BURNER_ROLE = keccak256("BURNER");
 bytes32 constant GOVERNOR_ROLE = keccak256("GOVERNOR");
 bytes32 constant GUARDIAN_ROLE = keccak256("GUARDIAN");
 bytes32 constant PAUSER_ROLE = keccak256("PAUSER");
+bytes32 constant RISK_MANAGER_ROLE = keccak256("RISK_MANAGER");
 
 interface IOverlayV1Token is IAccessControl, IERC20 {
     // mint/burn

--- a/tests/factories/market/conftest.py
+++ b/tests/factories/market/conftest.py
@@ -67,12 +67,19 @@ def guardian_role():
     yield web3.solidityKeccak(['string'], ["GUARDIAN"])
 
 
+@pytest.fixture(scope="module")
+def risk_manager_role():
+    yield web3.solidityKeccak(['string'], ["RISK_MANAGER"])
+
+
 @pytest.fixture(scope="module", params=[8000000])
-def create_token(gov, alice, bob, minter_role, request):
+def create_token(gov, alice, bob, minter_role, risk_manager_role, request):
     sup = request.param
 
     def create_token(supply=sup):
         tok = gov.deploy(OverlayV1Token)
+
+        tok.grantRole(risk_manager_role, gov, {"from": gov})
 
         # mint the token then renounce minter role
         tok.grantRole(minter_role, gov, {"from": gov})

--- a/tests/factories/market/test_setters.py
+++ b/tests/factories/market/test_setters.py
@@ -96,7 +96,7 @@ def test_set_risk_param_reverts_when_not_gov(factory, market, alice):
     expect_k = 361250000000
 
     # check can't set k with non gov account
-    with reverts("OVV1: !governor"):
+    with reverts("OVV1: !riskManager"):
         _ = factory.setRiskParam(feed, 0, expect_k, {"from": alice})
 
 

--- a/tests/markets/conftest.py
+++ b/tests/markets/conftest.py
@@ -78,7 +78,7 @@ def create_token(gov, alice, bob, minter_role, risk_manager_role, request):
 
     def create_token(supply=sup):
         tok = gov.deploy(OverlayV1Token)
-        
+
         tok.grantRole(risk_manager_role, gov, {"from": gov})
 
         # mint the token then renounce minter role

--- a/tests/markets/conftest.py
+++ b/tests/markets/conftest.py
@@ -67,12 +67,19 @@ def guardian_role():
     yield web3.solidityKeccak(['string'], ["GUARDIAN"])
 
 
+@pytest.fixture(scope="module")
+def risk_manager_role():
+    yield web3.solidityKeccak(['string'], ["RISK_MANAGER"])
+
+
 @pytest.fixture(scope="module", params=[8000000])
-def create_token(gov, alice, bob, minter_role, request):
+def create_token(gov, alice, bob, minter_role, risk_manager_role, request):
     sup = request.param
 
     def create_token(supply=sup):
         tok = gov.deploy(OverlayV1Token)
+        
+        tok.grantRole(risk_manager_role, gov, {"from": gov})
 
         # mint the token then renounce minter role
         tok.grantRole(minter_role, gov, {"from": gov})


### PR DESCRIPTION
*Solves #178*

```solidity
    /// @dev bound on notional cap to mitigate back-running attack
    /// @dev bound = macroWindowInBlocks * reserveInOv * 2 * delta
    function backRunBound(Oracle.Data memory data) public view returns (uint256) {
        uint256 averageBlockTime = params.get(Risk.Parameters.AverageBlockTime);
        uint256 window = (data.macroWindow * ONE * TO_MS) / averageBlockTime;
        uint256 delta = params.get(Risk.Parameters.Delta);
        return delta.mulDown(data.reserveOverMicroWindow).mulDown(window).mulDown(2 * ONE);
    }
```

[Reference code](https://github.com/overlay-market/v1-core/blob/1842c000f792f4ccb7b12d2b46f419289bb1fefe/contracts/OverlayV1Market.sol#L630-L637)

As @EperezOk mentions in this [comment](https://github.com/overlay-market/v1-core/pull/171#discussion_r1465726467) if the `averageBlockTime` decrease the `window` is increasead and also the `cap`(not visible in this segment of code).

Due the fact the current average block time of Arbitrum is 0.26s ([source](https://arbiscan.io/chart/blocktime)), we should set the `averageBlockTime` to this number and set an alarm to change it if necessary, for this purpose we add a new role named `RISK_MANAGER` that is able to change any Risk Parameter. This could be done automatically with a BOT or maybe using [Defender](https://www.openzeppelin.com/defender).

Note: In the current version of Overlay Protocol this code is unreachable because we are using [Chain Link Feed](https://github.com/overlay-market/v1-core/blob/1842c000f792f4ccb7b12d2b46f419289bb1fefe/contracts/feeds/chainlink/OverlayV1ChainlinkFeed.sol#L55) that sets the `hasReserve` property to `false` by default making any effort to solve this issue not necessary at the moment considering that adding a new feed also could lead to more modifications and a new audit.













