### PR TITLE
Feat: Ironblocks Firewall Integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -11,3 +11,6 @@
 	branch = 0.8
 	path = lib/v3-core
 	url = https://github.com/Uniswap/v3-core
+[submodule "lib/@ironblocks/firewall-consumer"]
+	path = lib/@ironblocks/firewall-consumer
+	url = https://github.com/ironblocks/firewall-consumer

--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -16,5 +16,6 @@ compiler:
       runs: 800
     remappings:
       - "@openzeppelin/=lib/openzeppelin-contracts/"
+      - "@ironblocks/firewall-consumer=lib/@ironblocks/firewall-consumer/"
       - "@chainlink/=lib/chainlink/"
       - "v3-core/=lib/v3-core/contracts/"

--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -12,6 +12,7 @@ dotenv: .env
 compiler:
   solc:
     version: 0.8.10
+    viaIR: True
     optimizer:
       runs: 800
     remappings:

--- a/contracts/OverlayV1Deployer.sol
+++ b/contracts/OverlayV1Deployer.sol
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.10;
 
+import "@ironblocks/firewall-consumer/contracts/FirewallConsumer.sol";
 import "./interfaces/IOverlayV1Deployer.sol";
 import "./OverlayV1Market.sol";
 
-contract OverlayV1Deployer is IOverlayV1Deployer {
+contract OverlayV1Deployer is FirewallConsumer, IOverlayV1Deployer {
     address public immutable factory; // factory that has gov permissions
     address public immutable ov; // ov token
 
@@ -27,7 +28,7 @@ contract OverlayV1Deployer is IOverlayV1Deployer {
         factory_ = factory;
     }
 
-    function deploy(address _feed) external onlyFactory returns (address market_) {
+    function deploy(address _feed) external onlyFactory firewallProtected returns (address market_) {
         // Use the CREATE2 opcode to deploy a new Market contract.
         // Will revert if market which accepts feed in its constructor has already
         // been deployed since salt would be the same and can't deploy with it twice.

--- a/contracts/OverlayV1Factory.sol
+++ b/contracts/OverlayV1Factory.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.10;
 
+import "@ironblocks/firewall-consumer/contracts/FirewallConsumer.sol";
 import "./interfaces/IOverlayV1Deployer.sol";
 import "./interfaces/IOverlayV1Factory.sol";
 import "./interfaces/IOverlayV1Market.sol";
@@ -12,7 +13,7 @@ import "./libraries/Risk.sol";
 
 import "./OverlayV1Deployer.sol";
 
-contract OverlayV1Factory is IOverlayV1Factory {
+contract OverlayV1Factory is FirewallConsumer, IOverlayV1Factory {
     using Risk for uint256[15];
 
     // risk param bounds
@@ -137,14 +138,14 @@ contract OverlayV1Factory is IOverlayV1Factory {
     }
 
     /// @dev adds a supported feed factory
-    function addFeedFactory(address feedFactory) external onlyGovernor {
+    function addFeedFactory(address feedFactory) external onlyGovernor firewallProtected {
         require(!isFeedFactory[feedFactory], "OVV1: feed factory already supported");
         isFeedFactory[feedFactory] = true;
         emit FeedFactoryAdded(msg.sender, feedFactory);
     }
 
     /// @dev removes a supported feed factory
-    function removeFeedFactory(address feedFactory) external onlyGovernor {
+    function removeFeedFactory(address feedFactory) external onlyGovernor firewallProtected {
         require(isFeedFactory[feedFactory], "OVV1: address not feed factory");
         isFeedFactory[feedFactory] = false;
         emit FeedFactoryRemoved(msg.sender, feedFactory);
@@ -155,6 +156,7 @@ contract OverlayV1Factory is IOverlayV1Factory {
     function deployMarket(address feedFactory, address feed, uint256[15] calldata params)
         external
         onlyGovernor
+        firewallProtected
         returns (address market_)
     {
         // check feed and feed factory are available for a new market
@@ -214,26 +216,26 @@ contract OverlayV1Factory is IOverlayV1Factory {
     }
 
     /// @notice Setter for fee repository
-    function setFeeRecipient(address _feeRecipient) external onlyGovernor {
+    function setFeeRecipient(address _feeRecipient) external onlyGovernor firewallProtected {
         require(_feeRecipient != address(0), "OVV1: feeRecipient should not be zero address");
         feeRecipient = _feeRecipient;
         emit FeeRecipientUpdated(msg.sender, _feeRecipient);
     }
 
     /// @notice Pause of market by governance in the event of an emergency
-    function pause(address feed) external onlyPauser {
+    function pause(address feed) external onlyPauser firewallProtected {
         OverlayV1Market market = OverlayV1Market(getMarket[feed]);
         market.pause();
     }
 
     /// @notice Unpause of market by governance in the event of an emergency
-    function unpause(address feed) external onlyPauser {
+    function unpause(address feed) external onlyPauser firewallProtected {
         OverlayV1Market market = OverlayV1Market(getMarket[feed]);
         market.unpause();
     }
 
     /// @notice Shut down of market by governance in the event of an emergency
-    function shutdown(address feed) external onlyGuardian {
+    function shutdown(address feed) external onlyGuardian firewallProtected {
         OverlayV1Market market = OverlayV1Market(getMarket[feed]);
         market.shutdown();
         emit EmergencyShutdown(msg.sender, address(market));

--- a/contracts/OverlayV1Token.sol
+++ b/contracts/OverlayV1Token.sol
@@ -1,21 +1,22 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.10;
 
+import "@ironblocks/firewall-consumer/contracts/FirewallConsumer.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/access/AccessControl.sol";
 
 import "./interfaces/IOverlayV1Token.sol";
 
-contract OverlayV1Token is IOverlayV1Token, AccessControl, ERC20("Overlay", "OV") {
+contract OverlayV1Token is FirewallConsumer, IOverlayV1Token, AccessControl, ERC20("Overlay", "OV") {
     constructor() {
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
     }
 
-    function mint(address _recipient, uint256 _amount) external onlyRole(MINTER_ROLE) {
+    function mint(address _recipient, uint256 _amount) external onlyRole(MINTER_ROLE) firewallProtected {
         _mint(_recipient, _amount);
     }
 
-    function burn(uint256 _amount) external onlyRole(BURNER_ROLE) {
+    function burn(uint256 _amount) external onlyRole(BURNER_ROLE) firewallProtected {
         _burn(msg.sender, _amount);
     }
 }

--- a/contracts/feeds/chainlink/OverlayV1ChainlinkFeed.sol
+++ b/contracts/feeds/chainlink/OverlayV1ChainlinkFeed.sol
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.10;
 
+import "@ironblocks/firewall-consumer/contracts/FirewallConsumer.sol";
 import "../OverlayV1Feed.sol";
 import "../../interfaces/IOverlayV1Token.sol";
 import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 
-contract OverlayV1ChainlinkFeed is OverlayV1Feed {
+contract OverlayV1ChainlinkFeed is FirewallConsumer, OverlayV1Feed {
     IOverlayV1Token public immutable ov;
     AggregatorV3Interface public immutable aggregator;
     uint8 public immutable decimals;
@@ -122,7 +123,7 @@ contract OverlayV1ChainlinkFeed is OverlayV1Feed {
             (sumOfPriceMacroWindowAgo * (10 ** 18)) / (macroWindow * 10 ** aggregator.decimals());
     }
 
-    function setHeartbeat(uint256 _heartbeat) external onlyGovernor {
+    function setHeartbeat(uint256 _heartbeat) external onlyGovernor firewallProtected {
         heartbeat = _heartbeat;
     }
 }

--- a/contracts/feeds/chainlink/OverlayV1ChainlinkFeedFactory.sol
+++ b/contracts/feeds/chainlink/OverlayV1ChainlinkFeedFactory.sol
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.10;
 
+import "@ironblocks/firewall-consumer/contracts/FirewallConsumer.sol";
 import "../OverlayV1FeedFactory.sol";
 import "./OverlayV1ChainlinkFeed.sol";
 import "../../interfaces/feeds/chainlink/IOverlayV1ChainlinkFeedFactory.sol";
 
-contract OverlayV1ChainlinkFeedFactory is IOverlayV1ChainlinkFeedFactory, OverlayV1FeedFactory {
+contract OverlayV1ChainlinkFeedFactory is FirewallConsumer, IOverlayV1ChainlinkFeedFactory, OverlayV1FeedFactory {
     address public immutable OV;
     // registry of feeds; for a given aggregator pair, returns associated feed
     mapping(address => address) public getFeed;
@@ -22,7 +23,7 @@ contract OverlayV1ChainlinkFeedFactory is IOverlayV1ChainlinkFeedFactory, Overla
     /// @param _heartbeat expected update frequency of the feed
     /// @return _feed address of the new feed
     function deployFeed(address _aggregator, uint256 _heartbeat)
-        external
+        external firewallProtected
         returns (address _feed)
     {
         // check feed doesn't already exist

--- a/foundry.toml
+++ b/foundry.toml
@@ -10,6 +10,7 @@ test = "tests"
 script = "scripts"
 out = "forge-out"
 libs = ["lib"]
+via-ir = true
 
 remappings = [
     "@openzeppelin/=lib/openzeppelin-contracts/",

--- a/foundry.toml
+++ b/foundry.toml
@@ -14,6 +14,7 @@ via-ir = true
 
 remappings = [
     "@openzeppelin/=lib/openzeppelin-contracts/",
+    "@ironblocks/firewall-consumer=lib/@ironblocks/firewall-consumer/",
     "@chainlink/=lib/chainlink/",
     "v3-core/=lib/v3-core/contracts/"
 ]


### PR DESCRIPTION
This PR introduces Ironblocks' Firewall to the **`overlay market`** contracts.

**Key Changes**
- Installed `@ironblocks/firewall-consumer`
- Import and inherit the `FirewallConsumer` in multiple contracts
- Add the firewallProtected modifiers to contract's functions

**Next Steps**
Once this PR is approved and merged, and the contracts are deployed, we can proceed to configuring Firewall Policies and begin testing the integration.