### PR TITLE
feat(market): emit Update event on every action

### DIFF
--- a/contracts/OverlayV1Market.sol
+++ b/contracts/OverlayV1Market.sol
@@ -211,7 +211,7 @@ contract OverlayV1Market is IOverlayV1Market, Pausable {
         // avoids stack too deep
         {
             // call to update before any effects
-            Oracle.Data memory data = _update();
+            Oracle.Data memory data = update();
 
             // calculate notional, oi, and trading fees. fees charged on notional
             // and added to collateral transferred in
@@ -317,7 +317,7 @@ contract OverlayV1Market is IOverlayV1Market, Pausable {
         // avoids stack too deep
         {
             // call to update before any effects
-            Oracle.Data memory data = _update();
+            Oracle.Data memory data = update();
 
             // check position exists
             pos = positions.get(msg.sender, positionId);
@@ -435,7 +435,7 @@ contract OverlayV1Market is IOverlayV1Market, Pausable {
             require(pos.exists(), "OVV1:!position");
 
             // call to update before any effects
-            Oracle.Data memory data = _update();
+            Oracle.Data memory data = update();
 
             // cache for gas savings
             uint256 oiTotalOnSide = pos.isLong ? oiLong : oiShort;
@@ -515,11 +515,7 @@ contract OverlayV1Market is IOverlayV1Market, Pausable {
 
     /// @dev updates market: pays funding and fetches freshest data from feed
     /// @dev update is called every time market is interacted with
-    function update() external returns (Oracle.Data memory data) {
-        data = _update();
-    }
-
-    function _update() internal whenNotPaused returns (Oracle.Data memory) {
+    function update() public whenNotPaused returns (Oracle.Data memory) {
         // pay funding for time elasped since last interaction w market
         _payFunding();
 

--- a/contracts/OverlayV1Market.sol
+++ b/contracts/OverlayV1Market.sol
@@ -148,7 +148,7 @@ contract OverlayV1Market is IOverlayV1Market, Pausable {
 
     /// @param oiLong oiLong after public update
     /// @param oiShort oiShort after public update
-    event PublicUpdate(uint256 oiLong, uint256 oiShort);
+    event Update(uint256 oiLong, uint256 oiShort);
 
     constructor() {
         (address _ov, address _feed, address _factory) =
@@ -517,10 +517,9 @@ contract OverlayV1Market is IOverlayV1Market, Pausable {
     /// @dev update is called every time market is interacted with
     function update() external returns (Oracle.Data memory data) {
         data = _update();
-        emit PublicUpdate(oiLong, oiShort);
     }
 
-    function _update() private whenNotPaused returns (Oracle.Data memory) {
+    function _update() internal whenNotPaused returns (Oracle.Data memory) {
         // pay funding for time elasped since last interaction w market
         _payFunding();
 
@@ -533,6 +532,7 @@ contract OverlayV1Market is IOverlayV1Market, Pausable {
         Oracle.Data memory data = IOverlayV1Feed(feed).latest();
         require(dataIsValid(data), "OVV1:!data");
 
+        emit Update(oiLong, oiShort);
         // return the latest data from feed
         return data;
     }

--- a/tests/OverlayV1Market.t.sol
+++ b/tests/OverlayV1Market.t.sol
@@ -172,9 +172,9 @@ contract MarketTest is Test {
         assertEq(ov.balanceOf(address(market)), 0);
     }
 
-    event PublicUpdate(uint256 oiLong, uint256 oiShort);
+    event Update(uint256 oiLong, uint256 oiShort);
 
-    function testUpdate() public {
+    function testUpdateEventEmitting() public {
         vm.startPrank(USER);
 
         ov.approve(address(market), type(uint256).max);
@@ -193,7 +193,7 @@ contract MarketTest is Test {
         uint256 newoiShort = isLongOverweight ? oiUnderweight : oiOverweight;
 
         vm.expectEmit(false, false, false, true);
-        emit PublicUpdate(newoiLong, newoiShort);
+        emit Update(newoiLong, newoiShort);
         market.update();
 
         vm.stopPrank();


### PR DESCRIPTION
This is the second version of [this](https://github.com/overlay-market/v1-core/pull/198) PR that emits `Update` even on every market action.